### PR TITLE
Fix session names in the Claude Code picker

### DIFF
--- a/src/editor-server.mjs
+++ b/src/editor-server.mjs
@@ -3,12 +3,13 @@
  */
 
 import { createServer } from "node:http";
-import { readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, unlinkSync, existsSync } from "node:fs";
+import { readFileSync, readdirSync, statSync, openSync, readSync, closeSync, writeFileSync, mkdirSync, unlinkSync, existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { resolve, join, dirname, sep } from "node:path";
 import { homedir } from "node:os";
 import { execFile } from "node:child_process";
 import { parseTranscript, filterTurns, detectFormat, applyPacedTiming } from "./parser.mjs";
+import { extractTitle } from "./formats/claude-code.mjs";
 import { render } from "./renderer.mjs";
 import { extractData } from "./extract.mjs";
 import { getTheme, listThemes } from "./themes.mjs";
@@ -332,6 +333,36 @@ function browseDirectory(dirPath) {
   return { path: resolved, parent: parent !== resolved ? parent : null, dirs, files };
 }
 
+/**
+ * Read up to `maxBytes` from the end of a file and return as a UTF-8 string.
+ * Drops the partial (potentially invalid) first line when we started mid-file.
+ * Returns "" on any error so callers can safely pass the result to extractTitle().
+ */
+function readTail(filePath, maxBytes = 65536) {
+  try {
+    const size = statSync(filePath).size;
+    const start = Math.max(0, size - maxBytes);
+    const length = size - start;
+    const buf = Buffer.alloc(length);
+    const fd = openSync(filePath, "r");
+    try {
+      readSync(fd, buf, 0, length, start);
+    } finally {
+      closeSync(fd);
+    }
+    let text = buf.toString("utf8");
+    // When we didn't start at the beginning of the file, the first line may be
+    // a partial JSON object; drop everything up to and including the first newline.
+    if (start > 0) {
+      const nl = text.indexOf("\n");
+      if (nl >= 0) text = text.slice(nl + 1);
+    }
+    return text;
+  } catch {
+    return "";
+  }
+}
+
 /** Discover session folders under Claude Code and Cursor project dirs. */
 function discoverSessions() {
   const home = homedir();
@@ -357,7 +388,8 @@ function discoverSessions() {
           const fullPath = join(projPath, f);
           let date = null;
           try { date = statSync(fullPath).mtime.toISOString(); } catch { /* ignore */ }
-          return { file: f, path: fullPath, date };
+          const title = extractTitle(readTail(fullPath)) || null;
+          return { file: f, path: fullPath, date, title };
         }).sort((a, b) => {
           if (!a.date && !b.date) return 0;
           if (!a.date) return 1;

--- a/src/formats/claude-code.mjs
+++ b/src/formats/claude-code.mjs
@@ -39,3 +39,39 @@ function parseEntries(text) {
 export function parse(text) {
   return buildTurnsFromEntries(parseEntries(text));
 }
+
+/**
+ * Extract a human-readable session title from Claude Code JSONL text.
+ *
+ * Scans all lines and returns the *last* title found (Claude appends updated
+ * titles throughout a session). Priority: custom-title > ai-title > agent-name.
+ * Returns null when no title entry is present.
+ *
+ * @param {string} text - Raw JSONL text (may be a tail slice of a large file)
+ * @returns {string|null}
+ */
+export function extractTitle(text) {
+  let custom = null;
+  let ai = null;
+  let agentName = null;
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj;
+    try { obj = JSON.parse(trimmed); } catch { continue; }
+    if (obj.type === "custom-title" && obj.customTitle) {
+      custom = obj.customTitle;
+    } else if (obj.type === "ai-title" && obj.aiTitle) {
+      ai = obj.aiTitle;
+    } else if (obj.type === "agent-name" && obj.agentName) {
+      agentName = obj.agentName;
+    }
+  }
+
+  const raw = custom ?? ai ?? agentName ?? null;
+  if (!raw) return null;
+  // Strip a single wrapping pair of double-quotes that Claude sometimes adds
+  const dequoted = raw.replace(/^"(.*)"$/, "$1").trim();
+  return dequoted || null;
+}

--- a/template/editor.html
+++ b/template/editor.html
@@ -1186,7 +1186,9 @@ body.sidebar-collapsed .sidebar-edge-toggle { left: 16px; }
         html += `<div class="session-list" id="${projId}">`;
         for (const sess of proj.sessions) {
           const dateStr = sess.date ? new Date(sess.date).toLocaleDateString() : "";
-          html += `<div class="session-item" data-path="${esc(sess.path)}">${esc(sess.file.replace(".jsonl", ""))} <span class="badge">${dateStr}</span></div>`;
+          const label = sess.title || sess.file.replace(".jsonl", "");
+          const uuid = sess.file.replace(".jsonl", "");
+          html += `<div class="session-item" data-path="${esc(sess.path)}" title="${esc(uuid)}">${esc(label)} <span class="badge">${dateStr}</span></div>`;
         }
         html += `</div></div>`;
       }

--- a/test/test-parser.mjs
+++ b/test/test-parser.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { parseTranscript, parseTranscriptFromText, filterTurns, detectFormat, detectFormatFromText, applyPacedTiming } from "../src/parser.mjs";
+import { extractTitle } from "../src/formats/claude-code.mjs";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -660,4 +661,82 @@ describe("Turn structure contract", () => {
       assert.deepEqual(indices, expected, `${name}: indices should be sequential`);
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// extractTitle
+// ---------------------------------------------------------------------------
+
+describe("extractTitle", () => {
+  const line = (obj) => JSON.stringify(obj);
+
+  it("returns null for empty text", () => {
+    assert.equal(extractTitle(""), null);
+  });
+
+  it("returns null when no title entries exist", () => {
+    const text = [
+      line({ type: "user", message: { role: "user", content: "hello" } }),
+      line({ type: "assistant", message: { role: "assistant", content: "hi" } }),
+    ].join("\n");
+    assert.equal(extractTitle(text), null);
+  });
+
+  it("returns ai-title value", () => {
+    const text = [
+      line({ type: "user", message: { role: "user", content: "hello" } }),
+      line({ type: "ai-title", aiTitle: "Explain VM Bundle concept", sessionId: "abc" }),
+    ].join("\n");
+    assert.equal(extractTitle(text), "Explain VM Bundle concept");
+  });
+
+  it("custom-title takes priority over ai-title", () => {
+    const text = [
+      line({ type: "ai-title", aiTitle: "AI generated title", sessionId: "abc" }),
+      line({ type: "custom-title", customTitle: "My custom name", sessionId: "abc" }),
+    ].join("\n");
+    assert.equal(extractTitle(text), "My custom name");
+  });
+
+  it("returns last custom-title when multiple exist", () => {
+    const text = [
+      line({ type: "custom-title", customTitle: "First title", sessionId: "abc" }),
+      line({ type: "custom-title", customTitle: "Updated title", sessionId: "abc" }),
+    ].join("\n");
+    assert.equal(extractTitle(text), "Updated title");
+  });
+
+  it("strips wrapping double-quotes from custom-title", () => {
+    const text = line({ type: "custom-title", customTitle: '"GDPR RLS Exploration"', sessionId: "abc" });
+    assert.equal(extractTitle(text), "GDPR RLS Exploration");
+  });
+
+  it("does not strip quotes that are not a complete outer wrapping pair", () => {
+    const text = line({ type: "ai-title", aiTitle: 'Fix "null" reference bug', sessionId: "abc" });
+    assert.equal(extractTitle(text), 'Fix "null" reference bug');
+  });
+
+  it("falls back to agent-name when no ai/custom title present", () => {
+    const text = [
+      line({ type: "agent-name", agentName: "presidio-pii-config-generator", sessionId: "abc" }),
+    ].join("\n");
+    assert.equal(extractTitle(text), "presidio-pii-config-generator");
+  });
+
+  it("custom-title takes priority over agent-name", () => {
+    const text = [
+      line({ type: "agent-name", agentName: "some-agent", sessionId: "abc" }),
+      line({ type: "custom-title", customTitle: "Real title", sessionId: "abc" }),
+    ].join("\n");
+    assert.equal(extractTitle(text), "Real title");
+  });
+
+  it("ignores malformed JSON lines", () => {
+    const text = [
+      "not-valid-json",
+      line({ type: "ai-title", aiTitle: "Valid title", sessionId: "abc" }),
+      "{broken",
+    ].join("\n");
+    assert.equal(extractTitle(text), "Valid title");
+  });
 });


### PR DESCRIPTION
The session picker was showing raw UUIDs for every Claude session — not exactly human-friendly. This PR makes it show the actual session title that Claude stores inside each transcript.

<img width="264" height="470" alt="Capture d’écran 2026-06-01 à 11 49 37" src="https://github.com/user-attachments/assets/c32f2378-fc24-4fae-900d-f9c1a1d12546" />

**What was happening:** The discovery code was only reading filenames and modification times, never opening the files. Since Claude names its files by UUID (`<uuid>.jsonl`), that's all we had to display.

**What's inside the files:** Claude appends title entries throughout a session — ai-title (auto-generated) and custom-title (user-set, takes priority). There's also agent-name for subagent transcripts as a last resort.

**How we read them efficiently:** Rather than loading entire files (some are 10+ MB), we tail-read only the last 64 KB — which is where the most recent title lives. Validated against 160 real sessions: 0 misses, perfect accuracy.

**Result:** 127/160 local sessions now show real names like "Debug failing job and tests in Qraft" instead of 1ac76e7b-b33a-4644-.... The ~20% without any title entry gracefully fall back to the UUID. Hovering a named session still shows the UUID as a tooltip.

Also strips the wrapping quotes Claude sometimes writes ("GDPR RLS Exploration" → GDPR RLS Exploration), and the name filter in the sidebar works against titles automatically since it reads element text content.

10 new unit tests cover the extraction logic.
251/251 tests pass ✅