### PR TITLE
Add kimi-code format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Codex CLI](https://img.shields.io/badge/Codex_CLI-replay-green)
 ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-replay-orange)
 ![OpenCode](https://img.shields.io/badge/OpenCode-replay-red)
+![Kimi Code](https://img.shields.io/badge/Kimi_Code-replay-teal)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Node.js](https://img.shields.io/badge/node-18%2B-green.svg)
 ![Zero Dependencies](https://img.shields.io/badge/dependencies-0-brightgreen)
@@ -14,13 +15,13 @@
 
 AI coding sessions are great for development, but hard to share. Screen recordings are bulky and transcripts are hard to navigate.
 
-**claude-replay** turns Claude Code, Cursor, Codex CLI, Gemini CLI, and OpenCode session logs into interactive, shareable HTML replays. The generated replay is a single self-contained HTML file with no external dependencies — you can email it, host it anywhere, or embed it in documentation. Use `--serve --watch` to monitor agent sessions live as they run.
+**claude-replay** turns Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, and Kimi Code session logs into interactive, shareable HTML replays. The generated replay is a single self-contained HTML file with no external dependencies — you can email it, host it anywhere, or embed it in documentation. Use `--serve --watch` to monitor agent sessions live as they run.
 
 ![Demo](https://raw.githubusercontent.com/es617/claude-replay/main/docs/demo.gif)
 
 **[Try it online](https://es617.dev/claude-replay/)** · **[Live demo](https://es617.dev/claude-replay/demo-redaction.html)**
 
-Claude Code, Cursor, Codex CLI, Gemini CLI, and OpenCode store conversation transcripts on disk. **claude-replay** auto-detects the format and converts them into visual replays suitable for blog posts, demos, and documentation.
+Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, and Kimi Code store conversation transcripts on disk. **claude-replay** auto-detects the format and converts them into visual replays suitable for blog posts, demos, and documentation.
 
 | Source | Transcript location |
 |---|---|
@@ -29,6 +30,7 @@ Claude Code, Cursor, Codex CLI, Gemini CLI, and OpenCode store conversation tran
 | Codex CLI | `~/.codex/sessions/<date>/` |
 | Gemini CLI | `~/.gemini/tmp/<projectHash>/chats/` |
 | OpenCode | Export via `opencode export <sessionID>` |
+| Kimi Code | `~/.kimi-code/sessions/<project>/<session>/agents/<name>/wire.jsonl` |
 
 ## Features
 
@@ -146,6 +148,10 @@ OpenCode transcripts are supported — the format is auto-detected. OpenCode sto
 opencode export <sessionID> > session.jsonl
 claude-replay session.jsonl -o replay.html
 ```
+
+### Kimi Code
+
+Kimi Code (Moonshot AI) transcripts are supported — the format is auto-detected. Kimi Code stores sessions as `wire.jsonl` under `~/.kimi-code/sessions/`, with each subagent in its own `agents/<name>/` directory; the web editor discovers the main session alongside any subagents. Thinking blocks and tool calls are rendered natively.
 
 ## Web Editor
 

--- a/bin/claude-replay.mjs
+++ b/bin/claude-replay.mjs
@@ -447,7 +447,7 @@ function buildReplay() {
     redactSecrets: !values["no-auto-redact"],
     redactRules,
     userLabel: values["user-label"],
-    assistantLabel: values["assistant-label"] || (format === "gemini" ? "Gemini" : format === "codex" ? "Codex" : format === "cursor" ? "Assistant" : format === "opencode" ? "OpenCode" : "Claude"),
+    assistantLabel: values["assistant-label"] || (format === "gemini" ? "Gemini" : format === "codex" ? "Codex" : format === "cursor" ? "Assistant" : format === "opencode" ? "OpenCode" : format === "kimi-code" ? "Kimi" : "Claude"),
     title,
     description: values.description,
     ogImage: values["og-image"],

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>claude-replay — Turn AI coding sessions into shareable HTML replays</title>
-<meta name="description" content="Convert Claude Code, Cursor, and Codex session logs into interactive, self-contained HTML replays.">
+<meta name="description" content="Convert Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, and Kimi Code session logs into interactive, self-contained HTML replays.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='14' fill='none' stroke='%23bb9af7' stroke-width='2'/><polygon points='12,8 12,24 24,16' fill='%23bb9af7'/></svg>">
 <style>
 :root {
@@ -113,7 +113,7 @@ kbd { background: var(--bg-surface); border: 1px solid var(--border); padding: 1
   <div class="hero">
     <h1><span class="accent">claude-replay</span></h1>
     <p>Turn AI coding sessions into interactive, shareable HTML replays.</p>
-    <p class="sub">Supports Claude Code, Cursor, and Codex transcripts. Single self-contained HTML file, zero dependencies.</p>
+    <p class="sub">Supports Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, and Kimi Code transcripts. Single self-contained HTML file, zero dependencies.</p>
     <div class="hero-actions">
       <div class="install-box" id="installNpm" title="Click to copy">
         <code>npm install -g claude-replay</code>
@@ -163,7 +163,7 @@ kbd { background: var(--bg-surface); border: 1px solid var(--border); padding: 1
   <div class="features">
     <h2>Features</h2>
     <div class="feature-grid">
-      <div class="feature-card"><h3>Multi-format</h3><p>Supports Claude Code, Cursor, and Codex CLI transcripts. Auto-detected.</p></div>
+      <div class="feature-card"><h3>Multi-format</h3><p>Supports Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, and Kimi Code transcripts. Auto-detected.</p></div>
       <div class="feature-card"><h3>Self-contained</h3><p>Single HTML file with no external dependencies. Email it, host it, embed it.</p></div>
       <div class="feature-card"><h3>Web Editor</h3><p>Built-in editor to browse sessions, edit prompts, exclude turns, and add bookmarks.</p></div>
       <div class="feature-card"><h3>Interactive Player</h3><p>Playback with speed control, keyboard shortcuts, diff views, and chapter navigation.</p></div>
@@ -189,8 +189,8 @@ var ClaudeReplay = (() => {
   var __getOwnPropNames = Object.getOwnPropertyNames;
   var __hasOwnProp = Object.prototype.hasOwnProperty;
   var __export = (target, all) => {
-    for (var name in all)
-      __defProp(target, name, { get: all[name], enumerable: true });
+    for (var name8 in all)
+      __defProp(target, name8, { get: all[name8], enumerable: true });
   };
   var __copyProps = (to, from, except, desc) => {
     if (from && typeof from === "object" || typeof from === "function") {
@@ -216,7 +216,16 @@ var ClaudeReplay = (() => {
     themeToCss: () => themeToCss
   });
 
-  // src/parser.mjs
+  // src/formats/claude-code.mjs
+  var claude_code_exports = {};
+  __export(claude_code_exports, {
+    detect: () => detect,
+    extractTitle: () => extractTitle,
+    name: () => name,
+    parse: () => parse
+  });
+
+  // src/formats/shared.mjs
   function cleanSystemTags(text) {
     text = text.replace(
       /<task-notification>\s*<task-id>[^<]*<\/task-id>\s*<output-file>[^<]*<\/output-file>\s*<status>([^<]*)<\/status>\s*<summary>([^<]*)<\/summary>\s*<\/task-notification>/g,
@@ -227,7 +236,7 @@ var ClaudeReplay = (() => {
     text = text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>\s*/g, "");
     text = text.replace(/<ide_opened_file>[\s\S]*?<\/ide_opened_file>\s*/g, "");
     text = text.replace(/<local-command-caveat>[\s\S]*?<\/local-command-caveat>\s*/g, "");
-    text = text.replace(/<command-name>([\s\S]*?)<\/command-name>\s*/g, (_, name) => name.trim() + "\n");
+    text = text.replace(/<command-name>([\s\S]*?)<\/command-name>\s*/g, (_, name8) => name8.trim() + "\n");
     text = text.replace(/<command-message>[\s\S]*?<\/command-message>\s*/g, "");
     text = text.replace(/<command-args>\s*<\/command-args>\s*/g, "");
     text = text.replace(/<command-args>([\s\S]*?)<\/command-args>\s*/g, (_, args) => {
@@ -248,58 +257,6 @@ var ClaudeReplay = (() => {
   function isToolResultOnly(content) {
     if (typeof content === "string") return false;
     return content.every((b) => b.type === "tool_result");
-  }
-  function detectFormatFromText(text) {
-    const trimmedFull = text.trim();
-    if (trimmedFull.startsWith("{")) {
-      try {
-        const obj = JSON.parse(trimmedFull);
-        if (obj.sessionId && Array.isArray(obj.messages)) return "gemini";
-      } catch {
-      }
-    }
-    for (const line of text.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        const obj = JSON.parse(trimmed);
-        if (obj.user_text !== void 0 && obj.blocks !== void 0) return "replay";
-        if (obj.type === "session_meta") return "codex";
-        if (obj.type === "thread.started" || obj.type === "item.completed" && obj.item) return "codex";
-        if (obj.sessionID && (obj.type === "step_start" || obj.type === "step_finish" || obj.type === "tool_use" || obj.type === "text" || obj.type === "reasoning" || obj.type === "error")) return "opencode";
-        if (obj.type === "user" || obj.type === "assistant") return "claude-code";
-        if (obj.role === "user" || obj.role === "assistant") return "cursor";
-      } catch {
-        continue;
-      }
-    }
-    return "unknown";
-  }
-  function parseJsonl(text) {
-    const entries = [];
-    let format = "unknown";
-    for (const line of text.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      let obj;
-      try {
-        obj = JSON.parse(trimmed);
-      } catch {
-        continue;
-      }
-      const topType = obj.type;
-      if (topType === "user" || topType === "assistant") {
-        if (format === "unknown") format = "claude-code";
-        entries.push(obj);
-      } else if (topType === void 0 || topType === null) {
-        const role = obj.message?.role ?? obj.role;
-        if (role === "user" || role === "assistant") {
-          if (format === "unknown") format = "cursor";
-          entries.push({ type: role, message: { role, content: obj.message?.content ?? "" }, timestamp: obj.timestamp ?? null });
-        }
-      }
-    }
-    return { entries, format };
   }
   function collectAssistantBlocks(entries, start) {
     const blocks = [];
@@ -401,6 +358,203 @@ var ClaudeReplay = (() => {
     }
     return i;
   }
+  function buildTurnsFromEntries(entries) {
+    const turns = [];
+    let i = 0;
+    let turnIndex = 0;
+    while (i < entries.length) {
+      const entry = entries[i];
+      const role = entry.message?.role ?? entry.type;
+      if (role === "user") {
+        const content = entry.message?.content ?? "";
+        if (isToolResultOnly(content)) {
+          i++;
+          continue;
+        }
+        let userText = extractText(content);
+        const timestamp = entry.timestamp ?? "";
+        i++;
+        while (i < entries.length) {
+          const next = entries[i];
+          const nextRole = next.message?.role ?? next.type;
+          if (nextRole !== "user") break;
+          const nextContent = next.message?.content ?? "";
+          if (isToolResultOnly(nextContent)) break;
+          const nextText = extractText(nextContent);
+          if (nextText) userText = userText ? userText + "\n" + nextText : nextText;
+          i++;
+        }
+        const systemEvents = [];
+        userText = userText.replace(/\[bg-task:\s*(.+)\]/g, (_, summary) => {
+          systemEvents.push(summary);
+          return "";
+        });
+        userText = userText.trim();
+        const [assistantBlocks, nextI] = collectAssistantBlocks(entries, i);
+        i = nextI;
+        i = attachToolResults(assistantBlocks, entries, i);
+        turnIndex++;
+        const turn = { index: turnIndex, user_text: userText, blocks: assistantBlocks, timestamp };
+        if (systemEvents.length) turn.system_events = systemEvents;
+        turns.push(turn);
+      } else if (role === "assistant") {
+        const [assistantBlocks, nextI] = collectAssistantBlocks(entries, i);
+        i = nextI;
+        i = attachToolResults(assistantBlocks, entries, i);
+        if (turns.length > 0) {
+          turns[turns.length - 1].blocks.push(...assistantBlocks);
+        } else {
+          turnIndex++;
+          turns.push({ index: turnIndex, user_text: "", blocks: assistantBlocks, timestamp: entry.timestamp ?? "" });
+        }
+      } else {
+        i++;
+      }
+    }
+    return filterEmptyTurns(turns);
+  }
+  function filterEmptyTurns(turns) {
+    const filtered = turns.filter((t) => {
+      if (t.user_text) return true;
+      if (t.system_events?.length) return true;
+      return t.blocks.some((b) => {
+        if (b.kind === "tool_use") return true;
+        if (b.kind === "text" && b.text && b.text !== "No response requested.") return true;
+        if (b.kind === "thinking" && b.text) return true;
+        return false;
+      });
+    });
+    for (let j = 0; j < filtered.length; j++) {
+      filtered[j].index = j + 1;
+    }
+    return filtered;
+  }
+
+  // src/formats/claude-code.mjs
+  var name = "claude-code";
+  function detect(firstObj) {
+    return firstObj.type === "user" || firstObj.type === "assistant";
+  }
+  function parseEntries(text) {
+    const entries = [];
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj;
+      try {
+        obj = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (obj.type === "user" || obj.type === "assistant") {
+        entries.push(obj);
+      }
+    }
+    return entries;
+  }
+  function parse(text) {
+    return buildTurnsFromEntries(parseEntries(text));
+  }
+  function extractTitle(text) {
+    let custom = null;
+    let ai = null;
+    let agentName = null;
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj;
+      try {
+        obj = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (obj.type === "custom-title" && obj.customTitle) {
+        custom = obj.customTitle;
+      } else if (obj.type === "ai-title" && obj.aiTitle) {
+        ai = obj.aiTitle;
+      } else if (obj.type === "agent-name" && obj.agentName) {
+        agentName = obj.agentName;
+      }
+    }
+    const raw = custom ?? ai ?? agentName ?? null;
+    if (!raw) return null;
+    const dequoted = raw.replace(/^"(.*)"$/, "$1").trim();
+    return dequoted || null;
+  }
+
+  // src/formats/cursor.mjs
+  var cursor_exports = {};
+  __export(cursor_exports, {
+    detect: () => detect2,
+    name: () => name2,
+    parse: () => parse2
+  });
+  var name2 = "cursor";
+  function detect2(firstObj) {
+    if (firstObj.type) return false;
+    return firstObj.role === "user" || firstObj.role === "assistant";
+  }
+  function parseEntries2(text) {
+    const entries = [];
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj;
+      try {
+        obj = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (obj.type) continue;
+      const role = obj.message?.role ?? obj.role;
+      if (role === "user" || role === "assistant") {
+        entries.push({
+          type: role,
+          message: { role, content: obj.message?.content ?? "" },
+          timestamp: obj.timestamp ?? null
+        });
+      }
+    }
+    return entries;
+  }
+  function parse2(text) {
+    const turns = buildTurnsFromEntries(parseEntries2(text));
+    for (const turn of turns) {
+      for (let j = 0; j < turn.blocks.length - 1; j++) {
+        if (turn.blocks[j].kind === "text") {
+          turn.blocks[j].kind = "thinking";
+        }
+      }
+    }
+    return turns;
+  }
+
+  // src/formats/codex.mjs
+  var codex_exports = {};
+  __export(codex_exports, {
+    detect: () => detect3,
+    name: () => name3,
+    parse: () => parse3
+  });
+  var name3 = "codex";
+  function detect3(firstObj) {
+    if (firstObj.type === "session_meta") return true;
+    if (firstObj.type === "thread.started") return true;
+    if (firstObj.type === "item.completed" && firstObj.item) return true;
+    return false;
+  }
+  function extractCodexUserText(text) {
+    const marker = "## My request for Codex:";
+    const idx = text.indexOf(marker);
+    if (idx !== -1) return text.slice(idx + marker.length).trim();
+    const marker2 = "## My request for Codex";
+    const idx2 = text.indexOf(marker2);
+    if (idx2 !== -1) {
+      const after = text.slice(idx2 + marker2.length);
+      return after.replace(/^:?\s*/, "").trim();
+    }
+    return text.trim();
+  }
   function parseCodexPatch(patchStr) {
     const lines = patchStr.split("\n");
     while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
@@ -433,271 +587,9 @@ var ClaudeReplay = (() => {
     if (isNew) {
       return { file_path: filePath, content: newLines.join("\n"), isNew: true };
     }
-    return {
-      file_path: filePath,
-      old_string: oldLines.join("\n"),
-      new_string: newLines.join("\n"),
-      isNew: false
-    };
+    return { file_path: filePath, old_string: oldLines.join("\n"), new_string: newLines.join("\n"), isNew: false };
   }
-  function extractCodexUserText(text) {
-    const marker = "## My request for Codex:";
-    const idx = text.indexOf(marker);
-    if (idx !== -1) return text.slice(idx + marker.length).trim();
-    const marker2 = "## My request for Codex";
-    const idx2 = text.indexOf(marker2);
-    if (idx2 !== -1) {
-      const after = text.slice(idx2 + marker2.length);
-      return after.replace(/^:?\s*/, "").trim();
-    }
-    return text.trim();
-  }
-  var GEMINI_TOOL_MAP = {
-    run_shell_command: "Bash",
-    shell: "Bash",
-    read_file: "Read",
-    read_many_files: "Read",
-    edit_file: "Edit",
-    write_file: "Write",
-    write_to_file: "Write",
-    list_directory: "Glob",
-    search_files: "Grep",
-    grep_search: "Grep",
-    web_search: "WebSearch",
-    web_fetch: "WebFetch",
-    complete_task: "complete_task"
-  };
-  function extractGeminiToolResult(result) {
-    if (!result) return null;
-    if (typeof result === "string") return result;
-    if (!Array.isArray(result) || result.length === 0) return null;
-    const fr = result[0]?.functionResponse;
-    if (!fr) return null;
-    const resp = fr.response;
-    if (!resp) return null;
-    const output = resp.output ?? "";
-    const error = resp.error ?? "";
-    if (!output && error && error !== "(none)") return error;
-    return output || null;
-  }
-  function parseGeminiTranscript(text) {
-    let data;
-    try {
-      data = JSON.parse(text);
-    } catch {
-      return [];
-    }
-    if (!data.messages || !Array.isArray(data.messages)) return [];
-    const turns = [];
-    let turnIndex = 0;
-    let currentUserText = "";
-    let currentTimestamp = "";
-    let currentBlocks = [];
-    function finalizeTurn() {
-      if (!currentUserText && currentBlocks.length === 0) return;
-      turnIndex++;
-      turns.push({
-        index: turnIndex,
-        user_text: currentUserText,
-        blocks: currentBlocks,
-        timestamp: currentTimestamp
-      });
-      currentUserText = "";
-      currentTimestamp = "";
-      currentBlocks = [];
-    }
-    for (const msg of data.messages) {
-      const type = msg.type;
-      const ts = msg.timestamp ?? null;
-      if (type === "user") {
-        finalizeTurn();
-        currentUserText = cleanSystemTags(msg.content ?? "");
-        currentTimestamp = ts ?? "";
-        continue;
-      }
-      if (type === "gemini") {
-        const thoughts = msg.thoughts ?? [];
-        for (const thought of thoughts) {
-          const subject = (thought.subject ?? "").trim();
-          const description = (thought.description ?? "").trim();
-          if (!description && !subject) continue;
-          const thinkText = subject ? `${subject}: ${description}` : description;
-          currentBlocks.push({ kind: "thinking", text: thinkText, tool_call: null, timestamp: thought.timestamp ?? ts });
-        }
-        const toolCalls = msg.toolCalls ?? [];
-        for (const tc of toolCalls) {
-          const rawName = tc.name ?? "unknown";
-          const mappedName = GEMINI_TOOL_MAP[rawName] ?? rawName;
-          const input = tc.args ?? {};
-          const normalizedInput = mappedName === "Bash" && input.command ? { command: input.command } : input;
-          const resultText = extractGeminiToolResult(tc.result);
-          const isError = tc.status === "error" || tc.result?.[0]?.functionResponse?.response?.exitCode != null && tc.result[0].functionResponse.response.exitCode !== 0;
-          currentBlocks.push({
-            kind: "tool_use",
-            text: "",
-            tool_call: {
-              tool_use_id: tc.id ?? "",
-              name: mappedName,
-              input: normalizedInput,
-              result: resultText,
-              resultTimestamp: tc.timestamp ?? null,
-              is_error: isError
-            },
-            timestamp: ts
-          });
-        }
-        const content = (msg.content ?? "").trim();
-        if (content) {
-          currentBlocks.push({ kind: "text", text: content, tool_call: null, timestamp: ts });
-        }
-        continue;
-      }
-    }
-    finalizeTurn();
-    const filtered = turns.filter((t) => {
-      if (t.user_text) return true;
-      return t.blocks.some((b) => b.kind === "tool_use" || b.kind === "text" && b.text || b.kind === "thinking" && b.text);
-    });
-    for (let j = 0; j < filtered.length; j++) {
-      filtered[j].index = j + 1;
-    }
-    return filtered;
-  }
-  var OPENCODE_TOOL_MAP = {
-    bash: "Bash",
-    read: "Read",
-    write: "Write",
-    edit: "Edit",
-    patch: "Edit",
-    glob: "Glob",
-    grep: "Grep",
-    ls: "Glob",
-    webfetch: "WebFetch",
-    websearch: "WebSearch",
-    codesearch: "Grep",
-    task: "Task",
-    todo: "TodoWrite"
-  };
-  function parseOpenCodeTranscript(text) {
-    const events = [];
-    for (const line of text.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        events.push(JSON.parse(trimmed));
-      } catch {
-        continue;
-      }
-    }
-    const turns = [];
-    let turnIndex = 0;
-    let currentBlocks = [];
-    let currentTimestamp = "";
-    function finalizeTurn() {
-      if (currentBlocks.length === 0) return;
-      turnIndex++;
-      turns.push({
-        index: turnIndex,
-        user_text: "",
-        blocks: currentBlocks,
-        timestamp: currentTimestamp
-      });
-      currentBlocks = [];
-      currentTimestamp = "";
-    }
-    for (const evt of events) {
-      const type = evt.type;
-      const part = evt.part ?? {};
-      const ts = evt.timestamp ? new Date(evt.timestamp).toISOString() : null;
-      if (type === "step_start") {
-        if (!currentTimestamp && ts) currentTimestamp = ts;
-        continue;
-      }
-      if (type === "tool_use") {
-        const rawName = part.tool ?? "unknown";
-        const mappedName = OPENCODE_TOOL_MAP[rawName] ?? rawName;
-        const state = part.state ?? {};
-        const input = state.input ?? {};
-        const output = state.output ?? "";
-        const isError = state.status === "error" || state.metadata?.exit != null && state.metadata.exit !== 0;
-        const resultTs = state.time?.end ? new Date(state.time.end).toISOString() : null;
-        let normalizedInput = input;
-        if (mappedName === "Bash" && input.command) {
-          normalizedInput = input.workdir ? { command: `cd ${input.workdir} && ${input.command}` } : { command: input.command };
-        } else if (mappedName === "Write" && input.filePath) {
-          normalizedInput = { file_path: input.filePath, content: input.content ?? "" };
-        } else if (mappedName === "Read" && input.filePath) {
-          normalizedInput = { file_path: input.filePath };
-        } else if (mappedName === "Edit" && input.filePath) {
-          normalizedInput = { file_path: input.filePath, ...input };
-        }
-        currentBlocks.push({
-          kind: "tool_use",
-          text: "",
-          tool_call: {
-            tool_use_id: part.callID ?? "",
-            name: mappedName,
-            input: normalizedInput,
-            result: typeof output === "string" ? output : JSON.stringify(output),
-            resultTimestamp: resultTs,
-            is_error: isError
-          },
-          timestamp: ts
-        });
-        continue;
-      }
-      if (type === "reasoning") {
-        const content = (part.text ?? "").trim();
-        if (content) {
-          currentBlocks.push({ kind: "thinking", text: content, tool_call: null, timestamp: ts });
-        }
-        continue;
-      }
-      if (type === "text") {
-        const content = (part.text ?? "").trim();
-        if (content) {
-          currentBlocks.push({ kind: "text", text: content, tool_call: null, timestamp: ts });
-        }
-        continue;
-      }
-      if (type === "step_finish") {
-        const reason = part.reason ?? "";
-        if (reason === "stop") {
-          finalizeTurn();
-        }
-        continue;
-      }
-      if (type === "error") {
-        const errData = evt.error ?? {};
-        const errMsg = errData.data?.message ?? errData.name ?? "Unknown error";
-        currentBlocks.push({ kind: "text", text: `Error: ${errMsg}`, tool_call: null, timestamp: ts });
-        finalizeTurn();
-        continue;
-      }
-    }
-    finalizeTurn();
-    for (let j = 0; j < turns.length; j++) {
-      turns[j].index = j + 1;
-    }
-    return turns;
-  }
-  function parseReplayJsonl(text) {
-    const turns = [];
-    for (const line of text.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        const obj = JSON.parse(trimmed);
-        if (obj.user_text !== void 0 || obj.blocks !== void 0) {
-          turns.push(obj);
-        }
-      } catch {
-        continue;
-      }
-    }
-    return turns;
-  }
-  function parseCodexNewFormat(events) {
+  function parseNewFormat(events) {
     const blocks = [];
     let userText = "";
     let timestamp = "";
@@ -710,53 +602,57 @@ var ClaudeReplay = (() => {
       if (itemType === "command_execution") {
         const cmd = typeof item.command === "string" ? item.command : String(item.command ?? "");
         const cleanCmd = cmd.replace(/^\/bin\/bash\s+-lc\s+/, "").replace(/^'(.*)'$/, "$1").replace(/^"(.*)"$/, "$1");
-        const toolCall = {
-          tool_use_id: item.id ?? "",
-          name: "Bash",
-          input: { command: cleanCmd },
-          result: (item.aggregated_output ?? "").trim(),
-          resultTimestamp: ts,
-          is_error: item.exit_code != null && item.exit_code !== 0
-        };
-        blocks.push({ kind: "tool_use", text: "", tool_call: toolCall, timestamp: ts });
+        blocks.push({
+          kind: "tool_use",
+          text: "",
+          tool_call: {
+            tool_use_id: item.id ?? "",
+            name: "Bash",
+            input: { command: cleanCmd },
+            result: (item.aggregated_output ?? "").trim(),
+            resultTimestamp: ts,
+            is_error: item.exit_code != null && item.exit_code !== 0
+          },
+          timestamp: ts
+        });
       } else if (itemType === "reasoning") {
         const text = item.text ?? "";
-        if (text.trim()) {
-          blocks.push({ kind: "thinking", text, tool_call: null, timestamp: ts });
-        }
+        if (text.trim()) blocks.push({ kind: "thinking", text, tool_call: null, timestamp: ts });
       } else if (itemType === "agent_message") {
         const text = item.text ?? "";
-        if (text.trim()) {
-          blocks.push({ kind: "text", text, tool_call: null, timestamp: ts });
-        }
+        if (text.trim()) blocks.push({ kind: "text", text, tool_call: null, timestamp: ts });
       } else if (itemType === "function_call") {
-        const name = item.name ?? "unknown";
+        const name8 = item.name ?? "unknown";
         let input = {};
         try {
           input = JSON.parse(item.arguments ?? "{}");
         } catch {
           input = { raw: item.arguments };
         }
-        if (name === "exec_command" && input.cmd) {
+        if (name8 === "exec_command" && input.cmd) {
           const cmd = input.workdir ? `cd ${input.workdir} && ${input.cmd}` : input.cmd;
           input = { command: cmd };
         }
-        let mappedName = name;
-        if (name === "exec_command") mappedName = "Bash";
-        if (name === "apply_patch") {
+        let mappedName = name8;
+        if (name8 === "exec_command") mappedName = "Bash";
+        if (name8 === "apply_patch") {
           const parsed = parseCodexPatch(item.arguments ?? input.raw ?? "");
           mappedName = parsed.isNew ? "Write" : "Edit";
           input = parsed;
         }
-        const toolCall = {
-          tool_use_id: item.id ?? "",
-          name: mappedName,
-          input,
-          result: (item.output ?? "").trim() || null,
-          resultTimestamp: ts,
-          is_error: item.status === "failed"
-        };
-        blocks.push({ kind: "tool_use", text: "", tool_call: toolCall, timestamp: ts });
+        blocks.push({
+          kind: "tool_use",
+          text: "",
+          tool_call: {
+            tool_use_id: item.id ?? "",
+            name: mappedName,
+            input,
+            result: (item.output ?? "").trim() || null,
+            resultTimestamp: ts,
+            is_error: item.status === "failed"
+          },
+          timestamp: ts
+        });
       } else if (itemType === "message" && item.role === "user") {
         const content = item.content ?? [];
         if (Array.isArray(content)) {
@@ -766,14 +662,9 @@ var ClaudeReplay = (() => {
       }
     }
     if (!blocks.length) return [];
-    return [{
-      index: 1,
-      user_text: userText || "Task",
-      blocks,
-      timestamp: timestamp || ""
-    }];
+    return [{ index: 1, user_text: userText || "Task", blocks, timestamp: timestamp || "" }];
   }
-  function parseCodexTranscript(text) {
+  function parse3(text) {
     const events = [];
     for (const line of text.split("\n")) {
       const trimmed = line.trim();
@@ -785,7 +676,7 @@ var ClaudeReplay = (() => {
       }
     }
     const isNewFormat = events.some((e) => e.type === "thread.started" || e.type === "item.completed");
-    if (isNewFormat) return parseCodexNewFormat(events);
+    if (isNewFormat) return parseNewFormat(events);
     const turns = [];
     let turnIndex = 0;
     let currentUserText = "";
@@ -808,12 +699,7 @@ var ClaudeReplay = (() => {
       if (type === "event_msg" && payload.type === "task_complete") {
         if (inTurn) {
           turnIndex++;
-          turns.push({
-            index: turnIndex,
-            user_text: currentUserText,
-            blocks: currentBlocks,
-            timestamp: currentTimestamp
-          });
+          turns.push({ index: turnIndex, user_text: currentUserText, blocks: currentBlocks, timestamp: currentTimestamp });
         }
         inTurn = false;
         continue;
@@ -857,20 +743,20 @@ var ClaudeReplay = (() => {
         if (ptype === "reasoning") continue;
         if (ptype === "function_call") {
           const callId = payload.call_id ?? "";
-          const name = payload.name ?? "unknown";
+          const fnName = payload.name ?? "unknown";
           let input = {};
           try {
             input = JSON.parse(payload.arguments ?? "{}");
           } catch {
             input = { raw: payload.arguments };
           }
-          if (name === "exec_command" && input.cmd) {
+          if (fnName === "exec_command" && input.cmd) {
             const cmd = input.workdir ? `cd ${input.workdir} && ${input.cmd}` : input.cmd;
             input = { command: cmd };
           }
           const toolCall = {
             tool_use_id: callId,
-            name: name === "exec_command" ? "Bash" : name,
+            name: fnName === "exec_command" ? "Bash" : fnName,
             input,
             result: null,
             resultTimestamp: null,
@@ -895,10 +781,10 @@ var ClaudeReplay = (() => {
         }
         if (ptype === "custom_tool_call") {
           const callId = payload.call_id ?? "";
-          const name = payload.name ?? "unknown";
-          let mappedName = name;
+          const toolName = payload.name ?? "unknown";
+          let mappedName = toolName;
           let input;
-          if (name === "apply_patch") {
+          if (toolName === "apply_patch") {
             const parsed = parseCodexPatch(payload.input ?? "");
             mappedName = parsed.isNew ? "Write" : "Edit";
             input = parsed;
@@ -938,114 +824,451 @@ var ClaudeReplay = (() => {
     }
     if (inTurn && (currentUserText || currentBlocks.length)) {
       turnIndex++;
-      turns.push({
-        index: turnIndex,
-        user_text: currentUserText,
-        blocks: currentBlocks,
-        timestamp: currentTimestamp
-      });
+      turns.push({ index: turnIndex, user_text: currentUserText, blocks: currentBlocks, timestamp: currentTimestamp });
     }
-    const filtered = turns.filter((t) => {
-      if (t.user_text) return true;
-      return t.blocks.some((b) => b.kind === "tool_use" || b.kind === "text" && b.text || b.kind === "thinking" && b.text);
-    });
-    for (let j = 0; j < filtered.length; j++) {
-      filtered[j].index = j + 1;
-    }
-    return filtered;
+    return filterEmptyTurns(turns);
   }
-  function parseTranscriptFromText(text) {
-    const format = detectFormatFromText(text);
-    if (format === "gemini") return parseGeminiTranscript(text);
-    if (format === "opencode") return parseOpenCodeTranscript(text);
-    if (format === "codex") return parseCodexTranscript(text);
-    if (format === "replay") return parseReplayJsonl(text);
-    const { entries, format: fmt } = parseJsonl(text);
+
+  // src/formats/gemini.mjs
+  var gemini_exports = {};
+  __export(gemini_exports, {
+    detect: () => detect4,
+    detectFromText: () => detectFromText,
+    name: () => name4,
+    parse: () => parse4
+  });
+  var name4 = "gemini";
+  function detectFromText(text) {
+    const trimmed = text.trim();
+    if (!trimmed.startsWith("{")) return false;
+    try {
+      const obj = JSON.parse(trimmed);
+      return !!(obj.sessionId && Array.isArray(obj.messages));
+    } catch {
+      return false;
+    }
+  }
+  function detect4() {
+    return false;
+  }
+  var TOOL_MAP = {
+    run_shell_command: "Bash",
+    shell: "Bash",
+    read_file: "Read",
+    read_many_files: "Read",
+    edit_file: "Edit",
+    write_file: "Write",
+    write_to_file: "Write",
+    list_directory: "Glob",
+    search_files: "Grep",
+    grep_search: "Grep",
+    web_search: "WebSearch",
+    web_fetch: "WebFetch",
+    complete_task: "complete_task"
+  };
+  function extractToolResult(result) {
+    if (!result) return null;
+    if (typeof result === "string") return result;
+    if (!Array.isArray(result) || result.length === 0) return null;
+    const fr = result[0]?.functionResponse;
+    if (!fr) return null;
+    const resp = fr.response;
+    if (!resp) return null;
+    const output = resp.output ?? "";
+    const error = resp.error ?? "";
+    if (!output && error && error !== "(none)") return error;
+    return output || null;
+  }
+  function parse4(text) {
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      return [];
+    }
+    if (!data.messages || !Array.isArray(data.messages)) return [];
     const turns = [];
-    let i = 0;
     let turnIndex = 0;
-    while (i < entries.length) {
-      const entry = entries[i];
-      const role = entry.message?.role ?? entry.type;
-      if (role === "user") {
-        const content = entry.message?.content ?? "";
-        if (isToolResultOnly(content)) {
-          i++;
-          continue;
+    let currentUserText = "";
+    let currentTimestamp = "";
+    let currentBlocks = [];
+    function finalizeTurn() {
+      if (!currentUserText && currentBlocks.length === 0) return;
+      turnIndex++;
+      turns.push({ index: turnIndex, user_text: currentUserText, blocks: currentBlocks, timestamp: currentTimestamp });
+      currentUserText = "";
+      currentTimestamp = "";
+      currentBlocks = [];
+    }
+    for (const msg of data.messages) {
+      const type = msg.type;
+      const ts = msg.timestamp ?? null;
+      if (type === "user") {
+        finalizeTurn();
+        currentUserText = cleanSystemTags(msg.content ?? "");
+        currentTimestamp = ts ?? "";
+        continue;
+      }
+      if (type === "gemini") {
+        const thoughts = msg.thoughts ?? [];
+        for (const thought of thoughts) {
+          const subject = (thought.subject ?? "").trim();
+          const description = (thought.description ?? "").trim();
+          if (!description && !subject) continue;
+          const thinkText = subject ? `${subject}: ${description}` : description;
+          currentBlocks.push({ kind: "thinking", text: thinkText, tool_call: null, timestamp: thought.timestamp ?? ts });
         }
-        let userText = extractText(content);
-        const timestamp = entry.timestamp ?? "";
-        i++;
-        while (i < entries.length) {
-          const next = entries[i];
-          const nextRole = next.message?.role ?? next.type;
-          if (nextRole !== "user") break;
-          const nextContent = next.message?.content ?? "";
-          if (isToolResultOnly(nextContent)) break;
-          const nextText = extractText(nextContent);
-          if (nextText) userText = userText ? userText + "\n" + nextText : nextText;
-          i++;
-        }
-        const systemEvents = [];
-        userText = userText.replace(/\[bg-task:\s*(.+)\]/g, (_, summary) => {
-          systemEvents.push(summary);
-          return "";
-        });
-        userText = userText.trim();
-        const [assistantBlocks, nextI] = collectAssistantBlocks(entries, i);
-        i = nextI;
-        i = attachToolResults(assistantBlocks, entries, i);
-        turnIndex++;
-        const turn = {
-          index: turnIndex,
-          user_text: userText,
-          blocks: assistantBlocks,
-          timestamp
-        };
-        if (systemEvents.length) turn.system_events = systemEvents;
-        turns.push(turn);
-      } else if (role === "assistant") {
-        const [assistantBlocks, nextI] = collectAssistantBlocks(entries, i);
-        i = nextI;
-        i = attachToolResults(assistantBlocks, entries, i);
-        if (turns.length > 0) {
-          turns[turns.length - 1].blocks.push(...assistantBlocks);
-        } else {
-          turnIndex++;
-          turns.push({
-            index: turnIndex,
-            user_text: "",
-            blocks: assistantBlocks,
-            timestamp: entry.timestamp ?? ""
+        const toolCalls = msg.toolCalls ?? [];
+        for (const tc of toolCalls) {
+          const rawName = tc.name ?? "unknown";
+          const mappedName = TOOL_MAP[rawName] ?? rawName;
+          const input = tc.args ?? {};
+          const normalizedInput = mappedName === "Bash" && input.command ? { command: input.command } : input;
+          const resultText = extractToolResult(tc.result);
+          const isError = tc.status === "error" || tc.result?.[0]?.functionResponse?.response?.exitCode != null && tc.result[0].functionResponse.response.exitCode !== 0;
+          currentBlocks.push({
+            kind: "tool_use",
+            text: "",
+            tool_call: {
+              tool_use_id: tc.id ?? "",
+              name: mappedName,
+              input: normalizedInput,
+              result: resultText,
+              resultTimestamp: tc.timestamp ?? null,
+              is_error: isError
+            },
+            timestamp: ts
           });
         }
-      } else {
-        i++;
+        const content = (msg.content ?? "").trim();
+        if (content) {
+          currentBlocks.push({ kind: "text", text: content, tool_call: null, timestamp: ts });
+        }
+        continue;
       }
     }
-    const filtered = turns.filter((t) => {
-      if (t.user_text) return true;
-      if (t.system_events?.length) return true;
-      return t.blocks.some((b) => {
-        if (b.kind === "tool_use") return true;
-        if (b.kind === "text" && b.text && b.text !== "No response requested.") return true;
-        if (b.kind === "thinking" && b.text) return true;
-        return false;
-      });
-    });
-    for (let j = 0; j < filtered.length; j++) {
-      filtered[j].index = j + 1;
+    finalizeTurn();
+    return filterEmptyTurns(turns);
+  }
+
+  // src/formats/kimi-code.mjs
+  var kimi_code_exports = {};
+  __export(kimi_code_exports, {
+    detect: () => detect5,
+    name: () => name5,
+    parse: () => parse5
+  });
+  var name5 = "kimi-code";
+  function detect5(firstObj) {
+    return firstObj.type === "turn.prompt" || firstObj.type === "context.append_loop_event";
+  }
+  function msToISO(ms) {
+    return new Date(ms).toISOString();
+  }
+  function extractUserText(input) {
+    if (!Array.isArray(input)) return "";
+    const parts = [];
+    for (const block of input) {
+      if (block.type === "text" && block.text) {
+        parts.push(block.text);
+      }
     }
-    if (fmt === "cursor") {
-      for (const turn of filtered) {
-        for (let j = 0; j < turn.blocks.length - 1; j++) {
-          if (turn.blocks[j].kind === "text") {
-            turn.blocks[j].kind = "thinking";
+    return cleanSystemTags(parts.join("\n"));
+  }
+  function parse5(text) {
+    const entries = [];
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        entries.push(JSON.parse(trimmed));
+      } catch {
+      }
+    }
+    const turnPrompts = [];
+    const loopEvents = /* @__PURE__ */ new Map();
+    let currentTurnId = "";
+    for (const entry of entries) {
+      if (entry.type === "turn.prompt") {
+        currentTurnId = String(turnPrompts.length);
+        turnPrompts.push({
+          turnId: currentTurnId,
+          input: entry.input,
+          time: entry.time
+        });
+      } else if (entry.type === "context.append_loop_event") {
+        const ev = entry.event;
+        if (!ev) continue;
+        const turnId = ev.turnId != null ? String(ev.turnId) : currentTurnId;
+        if (!loopEvents.has(turnId)) {
+          loopEvents.set(turnId, []);
+        }
+        loopEvents.get(turnId).push(ev);
+      }
+    }
+    const turns = [];
+    for (const tp of turnPrompts) {
+      const userText = extractUserText(tp.input);
+      const timestamp = tp.time ? msToISO(tp.time) : "";
+      const events = loopEvents.get(tp.turnId) ?? [];
+      const blocks = [];
+      const toolCalls = /* @__PURE__ */ new Map();
+      for (const ev of events) {
+        if (ev.type === "content.part") {
+          const part = ev.part;
+          if (!part) continue;
+          if (part.type === "think") {
+            const thinkText = (part.think ?? "").trim();
+            if (thinkText) {
+              blocks.push({
+                kind: "thinking",
+                text: thinkText,
+                tool_call: null,
+                timestamp: null
+              });
+            }
+          } else if (part.type === "text") {
+            const textContent = (part.text ?? "").trim();
+            if (textContent) {
+              blocks.push({
+                kind: "text",
+                text: textContent,
+                tool_call: null,
+                timestamp: null
+              });
+            }
+          }
+        } else if (ev.type === "tool.call") {
+          const toolId = ev.toolCallId ?? "";
+          const toolName = ev.name ?? "";
+          const args = ev.args ?? {};
+          const toolCall = {
+            tool_use_id: toolId,
+            name: toolName,
+            input: args,
+            result: null,
+            resultTimestamp: null,
+            is_error: false
+          };
+          toolCalls.set(toolId, toolCall);
+          blocks.push({
+            kind: "tool_use",
+            text: "",
+            tool_call: toolCall,
+            timestamp: null
+          });
+        } else if (ev.type === "tool.result") {
+          const toolId = ev.toolCallId ?? "";
+          const tc = toolCalls.get(toolId);
+          if (tc) {
+            const result = ev.result ?? {};
+            tc.result = result.output ?? null;
+            tc.is_error = !!result.isError;
+            tc.resultTimestamp = null;
           }
         }
       }
+      turns.push({
+        index: 0,
+        // Will be re-indexed by filterEmptyTurns
+        user_text: userText,
+        blocks,
+        timestamp
+      });
     }
-    return filtered;
+    return filterEmptyTurns(turns);
+  }
+
+  // src/formats/opencode.mjs
+  var opencode_exports = {};
+  __export(opencode_exports, {
+    detect: () => detect6,
+    name: () => name6,
+    parse: () => parse6
+  });
+  var name6 = "opencode";
+  function detect6(firstObj) {
+    const validTypes = /* @__PURE__ */ new Set(["step_start", "step_finish", "tool_use", "text", "reasoning", "error"]);
+    return !!(firstObj.sessionID && validTypes.has(firstObj.type));
+  }
+  var TOOL_MAP2 = {
+    bash: "Bash",
+    read: "Read",
+    write: "Write",
+    edit: "Edit",
+    patch: "Edit",
+    glob: "Glob",
+    grep: "Grep",
+    ls: "Glob",
+    webfetch: "WebFetch",
+    websearch: "WebSearch",
+    codesearch: "Grep",
+    task: "Task",
+    todo: "TodoWrite"
+  };
+  function parse6(text) {
+    const events = [];
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        events.push(JSON.parse(trimmed));
+      } catch {
+        continue;
+      }
+    }
+    const turns = [];
+    let turnIndex = 0;
+    let currentBlocks = [];
+    let currentTimestamp = "";
+    function finalizeTurn() {
+      if (currentBlocks.length === 0) return;
+      turnIndex++;
+      turns.push({ index: turnIndex, user_text: "", blocks: currentBlocks, timestamp: currentTimestamp });
+      currentBlocks = [];
+      currentTimestamp = "";
+    }
+    for (const evt of events) {
+      const type = evt.type;
+      const part = evt.part ?? {};
+      const ts = evt.timestamp ? new Date(evt.timestamp).toISOString() : null;
+      if (type === "step_start") {
+        if (!currentTimestamp && ts) currentTimestamp = ts;
+        continue;
+      }
+      if (type === "tool_use") {
+        const rawName = part.tool ?? "unknown";
+        const mappedName = TOOL_MAP2[rawName] ?? rawName;
+        const state = part.state ?? {};
+        const input = state.input ?? {};
+        const output = state.output ?? "";
+        const isError = state.status === "error" || state.metadata?.exit != null && state.metadata.exit !== 0;
+        const resultTs = state.time?.end ? new Date(state.time.end).toISOString() : null;
+        let normalizedInput = input;
+        if (mappedName === "Bash" && input.command) {
+          normalizedInput = input.workdir ? { command: `cd ${input.workdir} && ${input.command}` } : { command: input.command };
+        } else if (mappedName === "Write" && input.filePath) {
+          normalizedInput = { file_path: input.filePath, content: input.content ?? "" };
+        } else if (mappedName === "Read" && input.filePath) {
+          normalizedInput = { file_path: input.filePath };
+        } else if (mappedName === "Edit" && input.filePath) {
+          normalizedInput = { file_path: input.filePath, ...input };
+        }
+        currentBlocks.push({
+          kind: "tool_use",
+          text: "",
+          tool_call: {
+            tool_use_id: part.callID ?? "",
+            name: mappedName,
+            input: normalizedInput,
+            result: typeof output === "string" ? output : JSON.stringify(output),
+            resultTimestamp: resultTs,
+            is_error: isError
+          },
+          timestamp: ts
+        });
+        continue;
+      }
+      if (type === "reasoning") {
+        const content = (part.text ?? "").trim();
+        if (content) currentBlocks.push({ kind: "thinking", text: content, tool_call: null, timestamp: ts });
+        continue;
+      }
+      if (type === "text") {
+        const content = (part.text ?? "").trim();
+        if (content) currentBlocks.push({ kind: "text", text: content, tool_call: null, timestamp: ts });
+        continue;
+      }
+      if (type === "step_finish") {
+        const reason = part.reason ?? "";
+        if (reason === "stop") finalizeTurn();
+        continue;
+      }
+      if (type === "error") {
+        const errData = evt.error ?? {};
+        const errMsg = errData.data?.message ?? errData.name ?? "Unknown error";
+        currentBlocks.push({ kind: "text", text: `Error: ${errMsg}`, tool_call: null, timestamp: ts });
+        finalizeTurn();
+        continue;
+      }
+    }
+    finalizeTurn();
+    for (let j = 0; j < turns.length; j++) {
+      turns[j].index = j + 1;
+    }
+    return turns;
+  }
+
+  // src/formats/replay.mjs
+  var replay_exports = {};
+  __export(replay_exports, {
+    detect: () => detect7,
+    name: () => name7,
+    parse: () => parse7
+  });
+  var name7 = "replay";
+  function detect7(firstObj) {
+    return firstObj.user_text !== void 0 && firstObj.blocks !== void 0;
+  }
+  function parse7(text) {
+    const turns = [];
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed);
+        if (obj.user_text !== void 0 || obj.blocks !== void 0) {
+          turns.push(obj);
+        }
+      } catch {
+        continue;
+      }
+    }
+    return turns;
+  }
+
+  // src/formats/index.mjs
+  var formats = [
+    replay_exports,
+    codex_exports,
+    opencode_exports,
+    kimi_code_exports,
+    claude_code_exports,
+    cursor_exports
+  ];
+  var textDetectors = [
+    gemini_exports
+  ];
+  function detectFormatFromText(text) {
+    for (const fmt of textDetectors) {
+      if (fmt.detectFromText(text)) return fmt.name;
+    }
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj;
+      try {
+        obj = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      for (const fmt of formats) {
+        if (fmt.detect(obj)) return fmt.name;
+      }
+    }
+    return "unknown";
+  }
+  function parseFromText(text) {
+    const format = detectFormatFromText(text);
+    const allFormats = [...textDetectors, ...formats];
+    const fmt = allFormats.find((f) => f.name === format);
+    if (fmt) return fmt.parse(text);
+    return [];
+  }
+
+  // src/parser.mjs
+  function parseTranscriptFromText(text) {
+    return parseFromText(text);
   }
   function applyPacedTiming(turns) {
     let cursor = 0;
@@ -1231,12 +1454,12 @@ var ClaudeReplay = (() => {
     `
     }
   };
-  function getTheme(name) {
-    if (!(name in BUILTIN_THEMES)) {
+  function getTheme(name8) {
+    if (!(name8 in BUILTIN_THEMES)) {
       const available = Object.keys(BUILTIN_THEMES).sort().join(", ");
-      throw new Error(`Unknown theme '${name}'. Available: ${available}`);
+      throw new Error(`Unknown theme '${name8}'. Available: ${available}`);
     }
-    return BUILTIN_THEMES[name];
+    return BUILTIN_THEMES[name8];
   }
   function themeToCss(theme) {
     const lines = [];
@@ -1403,9 +1626,10 @@ var ClaudeReplay = (() => {
     html = html.replace('/*FONT_SIZE_NAME*/"normal"', JSON.stringify(fontSize));
     const embedData = (json) => escapeJsonForScript(json);
     html = html.replace("/*BOOKMARKS_DATA*/", () => embedData(JSON.stringify(bookmarks)));
+    const redactedTurns = turnsToJsonData(turns, { redact, redactRules });
     const files = [];
     const fileMap = /* @__PURE__ */ new Map();
-    for (const turn of turns) {
+    for (const turn of redactedTurns) {
       for (let bi = 0; bi < (turn.blocks || []).length; bi++) {
         const b = turn.blocks[bi];
         if (!b.tool_call?.input?.file_path) continue;
@@ -1437,7 +1661,7 @@ var ClaudeReplay = (() => {
 
 const { parseTranscriptFromText, detectFormatFromText, applyPacedTiming, getTheme, renderFromTemplate } = ClaudeReplay;
 
-const PLAYER_TEMPLATE = "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n<link rel=\"icon\" href=\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='14' fill='none' stroke='%23bb9af7' stroke-width='2'/><polygon points='12,8 12,24 24,16' fill='%23bb9af7'/><\/svg>\">\n<title>/*PAGE_TITLE*/<\/title>\n<meta name=\"theme-color\" content=\"/*THEME_BG*/\">\n<meta property=\"og:title\" content=\"/*PAGE_TITLE*/\">\n<meta property=\"og:description\" content=\"/*PAGE_DESCRIPTION*/\">\n<meta property=\"og:type\" content=\"website\">\n<meta property=\"og:image\" content=\"/*OG_IMAGE*/\">\n<meta name=\"twitter:card\" content=\"summary_large_image\">\n<meta name=\"twitter:title\" content=\"/*PAGE_TITLE*/\">\n<meta name=\"twitter:description\" content=\"/*PAGE_DESCRIPTION*/\">\n<meta name=\"twitter:image\" content=\"/*OG_IMAGE*/\">\n<style>\n/*THEME_CSS*/ *{margin:0;padding:0;box-sizing:border-box}body{background:var(--bg);color:var(--text);font-family:SF Mono,Cascadia Code,Fira Code,JetBrains Mono,Consolas,monospace;font-size:var(--font-size, /*FONT_SIZE*/13px);line-height:1.6;-webkit-text-size-adjust:100%;touch-action:manipulation}.container{max-width:960px;margin:0 auto;padding:0}.controls{position:fixed;bottom:0;left:50%;transform:translate(-50%);width:100%;max-width:960px;z-index:100;background:var(--bg-surface);border-top:1px solid var(--border);display:flex;flex-direction:column-reverse}.controls-row{display:flex;align-items:center;gap:8px 0;padding:8px;flex-wrap:wrap}.controls button{background:var(--bg-hover);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 10px;font-family:inherit;font-size:14px;cursor:pointer;transition:background .15s;flex-shrink:0;height:34px;min-width:34px;display:inline-flex;align-items:center;justify-content:center}.controls button:hover{background:var(--border)}#btn-play{width:36px}#btn-prev,#btn-next{min-width:30px;width:30px;font-size:13px}#btn-prev-turn,#btn-next-turn{min-width:26px;width:26px;font-size:10px;padding:2px}.nav-group{display:flex;align-items:center;gap:3px}.controls button.active{background:var(--accent-dim);border-color:var(--accent)}.bar-title{font-size:13px;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;text-decoration:none;margin:0 0 0 12px;flex:1;min-width:0}@media(max-width:480px){.bar-title{display:none}.nav-group{margin-right:auto}}body.in-iframe .bar-title{cursor:pointer}body.in-iframe .bar-title:after{content:\" \\2197\";font-size:9px}body.in-iframe .bar-title:hover{color:var(--text)}.progress-wrap{width:100%;display:flex;align-items:center;gap:8px;padding:0 12px 8px}.progress-bar{flex:1;height:4px;background:var(--bg);border-radius:2px;cursor:pointer;position:relative;transition:height .15s}.progress-bar:before{content:\"\";position:absolute;inset:-12px 0}.progress-bar:hover{height:6px}.progress-fill{height:100%;background:var(--accent);border-radius:2px;transition:width .2s}.progress-tooltip{position:absolute;bottom:12px;transform:translate(-50%);background:var(--bg-surface);border:1px solid var(--border);border-radius:4px;padding:3px 8px;font-size:11px;color:var(--text);white-space:nowrap;pointer-events:none;opacity:0;transition:opacity .15s;z-index:10}.progress-bar:hover .progress-tooltip{opacity:1}.progress-text{font-size:11px;color:var(--text-dim);white-space:nowrap;font-variant-numeric:tabular-nums;margin-left:12px}.speed-wrap{position:relative}.paced-toggle{display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-dim);cursor:pointer;white-space:nowrap;user-select:none;padding:4px 12px;border-top:1px solid var(--border);margin-top:2px}.controls-secondary button{width:34px;min-width:34px}.speed-wrap button#speed-btn{font-variant-numeric:tabular-nums;font-size:12px;letter-spacing:-.5px}.speed-popover{display:none;position:absolute;bottom:calc(100% + 6px);left:50%;transform:translate(-50%);background:var(--bg-surface);border:1px solid var(--border);border-radius:6px;padding:4px 0;z-index:200;box-shadow:0 4px 12px #0000004d;min-width:60px}.speed-wrap.open .speed-popover{display:block}.speed-popover button{display:block;width:100%;background:none;border:none;color:var(--text-dim);font-family:inherit;font-size:13px;font-variant-numeric:tabular-nums;padding:6px 16px;cursor:pointer;text-align:center;white-space:nowrap}.speed-popover button:hover{background:var(--bg-hover);color:var(--text)}.speed-popover button.active{color:var(--accent);font-weight:600}.filter-wrap{position:relative}.filter-popover{display:none;position:absolute;bottom:calc(100% + 6px);right:0;background:var(--bg-surface);border:1px solid var(--border);border-radius:6px;padding:8px 12px;z-index:200;box-shadow:0 4px 12px #0000004d;min-width:140px}.filter-wrap.open .filter-popover{display:block}.filter-popover label{display:flex;align-items:center;gap:6px;color:var(--text-dim);cursor:pointer;user-select:none;font-size:12px;padding:4px 0;white-space:nowrap}.filter-popover label:hover{color:var(--text)}.filter-popover input[type=checkbox]{accent-color:var(--accent)}.font-size-row{display:flex;align-items:center;gap:8px;padding:4px 0;border-top:1px solid var(--border);margin-top:4px;font-size:12px;color:var(--text-dim)}.font-size-row-label{min-width:50px}.font-size-cycle{background:var(--bg-hover);border:1px solid var(--border);color:var(--text-dim);border-radius:3px;cursor:pointer;padding:2px 8px;font-size:11px;font-family:inherit;min-width:28px;text-align:center}.font-size-cycle:hover{color:var(--text);border-color:var(--accent-dim)}.controls-secondary{display:flex;align-items:center;gap:4px;margin-left:6px;flex-wrap:wrap;justify-content:center}.more-wrap{position:relative;display:none;margin-left:6px}@media(max-width:600px){.more-wrap{display:block}}.more-popover{display:none;position:absolute;bottom:calc(100% + 6px);right:0;background:var(--bg-surface);border:1px solid var(--border);border-radius:6px;padding:8px 12px;z-index:200;box-shadow:0 4px 12px #0000004d;min-width:180px;max-height:40vh;overflow-y:auto}.more-wrap.open .more-popover{display:block}.more-open-link{display:none;font-size:12px;color:var(--text-dim);text-decoration:none;padding:4px 0;white-space:nowrap}.more-open-link+hr.more-divider{display:none}body.in-iframe .more-open-link{display:block}body.in-iframe .more-open-link+hr.more-divider{display:block}.more-open-link:hover{color:var(--text)}.more-popover label{display:flex;align-items:center;gap:6px;color:var(--text-dim);cursor:pointer;user-select:none;font-size:12px;padding:4px 0;white-space:nowrap}.more-popover label:hover{color:var(--text)}.more-popover input[type=checkbox]{accent-color:var(--accent)}.more-popover .more-row{display:flex;align-items:center;gap:8px;padding:4px 0;font-size:12px;color:var(--text-dim)}.more-popover .more-row-label{min-width:50px}.more-divider{border:none;border-top:1px solid var(--border);margin:4px 0}#more-btn{background:none!important;border:none!important;font-size:16px;font-weight:700;min-width:20px;width:20px;padding:0;justify-content:flex-end}#chapter-btn{font-size:16px}@media(max-width:600px){body:not(.in-iframe) .controls-secondary{display:none}body:not(.in-iframe) .chapter-wrap{display:none!important}}@media(max-width:600px){body.in-iframe .controls-secondary{display:none}body.in-iframe .chapter-wrap{display:none!important}}.transcript{padding:calc(100vh - 80px) 16px 100vh;min-height:100vh}.turn{margin-bottom:24px;opacity:.25;transition:opacity .4s}.turn.visible{opacity:.35}.turn.visible.active{opacity:1}.user-msg{margin-bottom:8px}.user-prompt{color:var(--accent);font-weight:600}.user-text{color:var(--text-bright);word-break:break-word}.timestamp{font-size:10px;color:var(--text-dim);margin-bottom:4px}.assistant-text{color:var(--text);word-break:break-word;margin:6px 0;padding-left:4px;line-height:1.6}.assistant-text p{margin:.4em 0}.assistant-text pre{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px 12px;overflow-x:auto;margin:8px 0;line-height:1.4}.assistant-text pre code{background:none;padding:0;border-radius:0;font-size:inherit}.assistant-text code{background:var(--bg);padding:1px 5px;border-radius:3px;font-size:.92em}.assistant-text h3,.assistant-text h4,.assistant-text h5,.assistant-text h6{color:var(--text-bright);margin:.8em 0 .3em;line-height:1.3}.assistant-text h3{font-size:1.15em}.assistant-text h4{font-size:1.05em}.assistant-text h5,.assistant-text h6{font-size:1em}.assistant-text ul,.assistant-text ol{margin:.4em 0;padding-left:1.6em}.assistant-text li{margin:.15em 0}.assistant-text a{color:var(--blue);text-decoration:underline;text-decoration-color:color-mix(in srgb,var(--blue) 40%,transparent)}.assistant-text a:hover{text-decoration-color:var(--blue)}.assistant-text strong{color:var(--text-bright)}.assistant-text hr{border:none;border-top:1px solid var(--border);margin:.8em 0}.assistant-text table,.user-text table,.thinking-body table{border-collapse:collapse;margin:8px 0;font-size:.95em;width:auto;overflow-x:auto;display:block}.assistant-text th,.assistant-text td,.user-text th,.user-text td,.thinking-body th,.thinking-body td{border:1px solid var(--border);padding:4px 10px;text-align:left}.assistant-text th,.user-text th,.thinking-body th{background:var(--bg-surface);color:var(--text-bright);font-weight:600}.bg-task-badge{display:inline-block;background:var(--bg-surface);border:1px solid var(--border);border-radius:4px;padding:2px 8px;font-size:12px;color:var(--text);margin:4px 0}.bg-task-badge:before{content:\"\\26a1  \"}.user-text pre,.thinking-body pre{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px 12px;overflow-x:auto;margin:8px 0}.user-text pre code,.thinking-body pre code{background:none;padding:0;border-radius:0}.user-text code,.thinking-body code{background:var(--bg);padding:1px 5px;border-radius:3px;font-size:.92em}.user-text a,.thinking-body a{color:var(--blue);text-decoration:underline}.user-text strong,.thinking-body strong{color:var(--text-bright)}.user-text ul,.user-text ol,.thinking-body ul,.thinking-body ol{margin:.4em 0;padding-left:1.6em}.user-text p,.thinking-body p{margin:.4em 0}.tool-block{margin:6px 0;border:1px solid var(--border);border-radius:6px;overflow:hidden;background:var(--tool-bg)}.tool-header{display:flex;align-items:center;gap:6px;padding:6px 10px;cursor:pointer;user-select:none;transition:background .15s}.tool-header:hover{background:var(--bg-hover)}.tool-indicator{width:8px;height:8px;border-radius:50%;background:var(--blue);flex-shrink:0}.tool-name{color:var(--cyan);font-weight:600}.tool-args-preview{color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.tool-chevron{color:var(--text-dim);font-size:10px;transition:transform .2s;flex-shrink:0}.tool-block.open .tool-chevron{transform:rotate(90deg)}.tool-body{display:none;border-top:1px solid var(--border)}.tool-block.open .tool-body{display:block}.tool-input,.tool-result{padding:8px 10px;font-size:12px;white-space:pre-wrap;word-break:break-word;max-height:300px;overflow-y:auto}.tool-input{color:var(--text-dim);background:var(--tool-bg)}.tool-result{background:var(--bg);border-top:1px solid var(--border);color:var(--green)}.tool-result-label,.tool-input-label{font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:var(--text-dim);margin-bottom:4px;font-weight:600}.diff-view{font-family:inherit;font-size:12px;padding:8px 10px;white-space:pre-wrap;word-break:break-word;max-height:300px;overflow-y:auto}.diff-file{color:var(--text-dim);font-size:11px;margin-bottom:6px}.diff-line-del{color:var(--red);background:#f851491a}.diff-line-add{color:var(--green);background:#3fb9501a}.diff-line-ctx{color:var(--text-dim)}.diff-result{color:var(--text-dim);font-size:11px;padding:6px 10px;border-top:1px solid var(--border)}.diff-result-error{color:var(--red)}.tool-indicator.tool-error{background:var(--red)}.tool-result.tool-result-error{color:var(--red)}.tool-group{margin:6px 0}.tool-group-header{display:flex;align-items:center;gap:6px;padding:6px 10px;cursor:pointer;user-select:none;font-size:12px;color:var(--cyan);font-weight:600;border:1px solid var(--border);border-radius:6px;background:var(--tool-bg);transition:background .15s}.tool-group-header:hover{background:var(--bg-hover)}.tool-group-chevron{font-size:10px;color:var(--text-dim);transition:transform .2s}.tool-group.open .tool-group-chevron{transform:rotate(90deg)}.tool-group-names{color:var(--text-dim);font-weight:400;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.tool-group-body{display:none}.tool-group.open .tool-group-body{display:block}.tool-group.open .tool-group-header{border-radius:6px 6px 0 0;border-bottom:none}.thinking-block{margin:6px 0;border-left:2px solid var(--text-dim);padding-left:10px}.thinking-header{font-size:11px;color:var(--text);cursor:pointer;user-select:none;display:flex;align-items:center;gap:4px}.thinking-chevron{font-size:10px;transition:transform .2s}.thinking-block.open .thinking-chevron{transform:rotate(90deg)}.thinking-body{display:none;color:var(--text-dim);font-size:12px;word-break:break-word;margin-top:4px;max-height:400px;overflow-y:auto}.thinking-block.open .thinking-body{display:block}.turn-header{display:flex;align-items:center;gap:8px;padding:6px 12px;background:var(--bg-surface);border-bottom:1px solid var(--border);border-radius:6px 6px 0 0;cursor:pointer;user-select:none;font-size:11px;color:var(--text-dim)}.turn-header:hover{background:var(--bg-hover)}.turn-header-chevron{font-size:10px;transition:transform .2s}.turn.collapsed .turn-header-chevron{transform:rotate(-90deg)}.turn-header-label{font-weight:600;color:var(--text)}.turn-header-ts{margin-left:auto;font-size:10px}.turn-body{overflow:hidden;transition:max-height .3s ease}.turn.collapsed .turn-body{display:none}.role-section{padding:8px 12px;margin:4px 0;border-radius:4px}.role-section.role-user{background:var(--bg-surface);border-left:3px solid var(--accent)}.role-section.role-assistant{border-left:3px solid var(--cyan)}.role-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;margin-bottom:4px}.role-label.role-user-label{color:var(--accent)}.role-label.role-assistant-label{color:var(--cyan)}.role-label.role-system-label{color:var(--text);font-style:italic}.collapsible-wrap{position:relative}.collapsible-wrap.is-collapsed .collapsible-content{max-height:13em;overflow:hidden}.collapsible-wrap.is-collapsed .collapsible-fade{display:block;position:absolute;bottom:24px;left:0;right:0;height:3em;background:linear-gradient(transparent,var(--bg));pointer-events:none}.role-section.role-user .collapsible-wrap.is-collapsed .collapsible-fade{background:linear-gradient(transparent,var(--bg-surface))}.collapsible-fade{display:none}.collapsible-toggle{display:inline-block;font-size:11px;color:var(--accent);cursor:pointer;padding:2px 0;user-select:none;border:none;background:none;font-family:inherit}.collapsible-toggle:hover{text-decoration:underline}.cursor{display:inline-block;width:7px;height:14px;background:var(--accent);animation:blink 1s step-end infinite;vertical-align:text-bottom;margin-left:2px}@keyframes blink{50%{opacity:0}}.block-spinner{display:none;width:10px;height:10px;border:1.5px solid var(--text-dim);border-top-color:var(--text);border-radius:50%;animation:spin .8s linear infinite;flex-shrink:0}.block-active .block-spinner{display:inline-block}.block-active{border-left:2px solid var(--accent);padding-left:6px}@keyframes spin{to{transform:rotate(360deg)}}@media(max-width:600px){.controls-row{padding:6px 8px}.controls button{min-height:40px;min-width:40px;padding:6px 10px;font-size:14px}.filter-popover label{font-size:14px;padding:6px 0}.filter-popover input[type=checkbox]{width:18px;height:18px}.controls-secondary{gap:10px}}.turn-dot{position:absolute;width:5px;height:5px;border-radius:50%;background:var(--text-dim);top:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:1;opacity:.5}.turn-dot.reached{opacity:1;background:var(--text)}.bookmark-dot{position:absolute;width:8px;height:8px;border-radius:50%;background:var(--orange);top:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:2;opacity:.3;transition:opacity .3s,transform .15s}.bookmark-dot.reached{opacity:.6}.bookmark-dot.active{opacity:1;transform:translate(-50%,-50%) scale(1.4)}.bookmark-divider{display:flex;align-items:center;gap:8px;margin:16px 0 8px;padding:4px 0 4px 8px;border-left:3px solid var(--orange);font-size:11px;font-weight:600;color:var(--orange);text-transform:uppercase;letter-spacing:.5px;opacity:.25;transition:opacity .4s}.bookmark-divider.visible{opacity:1}.chapter-wrap{position:relative;flex-shrink:0}.chapter-menu{display:none;position:absolute;bottom:calc(100% + 6px);left:50%;transform:translate(-50%);background:var(--bg-surface);border:1px solid var(--border);border-radius:6px;padding:4px 0;z-index:200;box-shadow:0 4px 12px #0000004d;min-width:160px;max-width:280px;max-height:300px;overflow-y:auto}.chapter-wrap.open .chapter-menu{display:block}.chapter-item{display:flex;align-items:center;gap:8px;padding:6px 12px;cursor:pointer;font-size:12px;color:var(--text);white-space:nowrap;transition:background .15s}.chapter-item:hover{background:var(--bg-hover)}.chapter-item-turn{color:var(--text-dim);font-size:10px;min-width:24px}.chapter-item-label{color:var(--orange);font-weight:600;overflow:hidden;text-overflow:ellipsis}.splash{position:fixed;inset:0;z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:32px;background:var(--bg)}.splash.hidden{display:none}.splash-title{color:var(--text);font-size:22px;font-weight:600;text-align:center;max-width:600px;padding:0 24px}.splash-play{width:64px;height:64px;border-radius:50%;border:2px solid var(--accent);background:transparent;color:var(--accent);font-size:24px;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .2s,color .2s;padding-left:4px}.splash-play:hover{background:var(--accent);color:var(--bg)}.block-hidden{display:none}.block-revealing{animation:blockFadeIn .2s ease-out}@keyframes blockFadeIn{0%{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}::-webkit-scrollbar{width:6px;height:6px}::-webkit-scrollbar-track{background:transparent}::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}::-webkit-scrollbar-thumb:hover{background:var(--text-dim)}.file-sidebar{position:fixed;top:0;right:max(0px,calc((100vw - 960px)/2));width:260px;bottom:0;background:var(--bg-surface);border-left:1px solid var(--border);z-index:90;display:none;flex-direction:column;font-size:12px}.file-sidebar.open{display:flex}.file-sidebar-header{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border-bottom:1px solid var(--border);flex-shrink:0}.file-sidebar-title{font-weight:600;color:var(--text)}.file-sidebar-count{color:var(--text-dim);font-weight:400}.file-sidebar-close{background:none;border:none;color:var(--text-dim);font-size:18px;cursor:pointer;padding:0 4px}.file-sidebar-close:hover{color:var(--text)}.file-sidebar-list{flex:1;min-height:0;overflow-y:auto;padding:8px 0}.file-entry{padding:0}.file-entry-header{display:flex;align-items:center;gap:6px;padding:5px 12px;cursor:pointer;color:var(--text);user-select:none}.file-entry-header:hover{background:var(--bg-hover)}.file-entry-header.active{border-left:2px solid var(--accent);padding-left:10px;color:var(--accent)}.file-entry-chevron{font-size:8px;color:var(--text-dim);transition:transform .15s;flex-shrink:0}.file-entry.expanded .file-entry-chevron{transform:rotate(90deg)}.file-entry-name{flex:1;overflow:hidden;min-width:0}.file-entry-name-main{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.file-entry-name-path{display:block;font-size:9px;color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.file-entry-badge{font-size:10px;color:var(--text-dim);background:var(--bg-hover);padding:1px 5px;border-radius:8px;flex-shrink:0}.file-entry-refs{display:none;padding:2px 12px 6px 32px}.file-entry.expanded .file-entry-refs{display:block}.file-entry-ref{display:block;padding:3px 8px;margin:1px 0;color:var(--text-dim);font-size:11px;cursor:pointer;border-radius:3px;text-decoration:none}.file-entry-ref:hover{background:var(--bg-hover);color:var(--text)}.file-entry-ref .ref-tool{color:var(--accent)}.file-sidebar-toggle{font-size:13px}.file-sidebar-toggle2{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--text-dim);text-decoration:none;padding:4px 0;cursor:pointer;white-space:nowrap}.file-sidebar-toggle2:hover{color:var(--text)}\n<\/style>\n<\/head>\n<body>\n<div class=\"container\">\n  <div class=\"controls\">\n    <div class=\"controls-row\">\n      <div class=\"nav-group\">\n        <button id=\"btn-prev-turn\" title=\"Previous turn\">&#x23EE;&#xFE0E;<\/button>\n        <button id=\"btn-prev\" title=\"Previous block\">&larr;<\/button>\n        <button id=\"btn-play\" title=\"Play / Pause\">&#9654;<\/button>\n        <button id=\"btn-next\" title=\"Next block\">&rarr;<\/button>\n        <button id=\"btn-next-turn\" title=\"Next turn\">&#x23ED;&#xFE0E;<\/button>\n      <\/div>\n      <a class=\"bar-title\" id=\"bar-title\" title=\"/*PAGE_TITLE*/\">/*PAGE_TITLE*/<\/a>\n      <span class=\"progress-text\" id=\"progress-text\">0 of 0<\/span>\n      <div class=\"controls-secondary\">\n        <div class=\"chapter-wrap\" id=\"chapter-wrap\" style=\"display:none\">\n          <button id=\"chapter-btn\" title=\"Chapters\">&#9776;<\/button>\n          <div class=\"chapter-menu\" id=\"chapter-menu\"><\/div>\n        <\/div>\n        <div class=\"speed-wrap\" id=\"speed-wrap\">\n          <button id=\"speed-btn\" title=\"Speed\">/*INITIAL_SPEED*/x<\/button>\n          <div class=\"speed-popover\" id=\"speed-popover\"><\/div>\n        <\/div>\n        <div class=\"filter-wrap\" id=\"filter-wrap\">\n          <button id=\"filter-btn\" title=\"Filter content\"><svg width=\"14\" height=\"14\" viewBox=\"0 0 16 16\" fill=\"currentColor\"><path d=\"M1 2.5A.5.5 0 0 1 1.5 2h13a.5.5 0 0 1 .4.8L10 8.7V13.5a.5.5 0 0 1-.7.5l-2.5-1.2a.5.5 0 0 1-.3-.5V8.7L1.1 2.8A.5.5 0 0 1 1 2.5z\"/><\/svg><\/button>\n          <div class=\"filter-popover\">\n            <label><input type=\"checkbox\" id=\"toggle-thinking\" /*CHECKED_THINKING*/> Thinking<\/label>\n            <label><input type=\"checkbox\" id=\"toggle-tools\" /*CHECKED_TOOLS*/> Tools<\/label>\n            <div class=\"font-size-row\">\n              <span class=\"font-size-row-label\">Font<\/span>\n              <button class=\"font-size-cycle\" id=\"font-size-cycle\" title=\"Cycle font size\">M<\/button>\n            <\/div>\n          <\/div>\n        <\/div>\n        <button class=\"file-sidebar-toggle\" id=\"fileSidebarToggle\" title=\"Files\" style=\"display:none\"><svg width=\"14\" height=\"14\" viewBox=\"0 0 16 16\" fill=\"currentColor\"><path d=\"M3.5 0A1.5 1.5 0 0 0 2 1.5v13A1.5 1.5 0 0 0 3.5 16h9a1.5 1.5 0 0 0 1.5-1.5V4.5L10 0H3.5zM10 1l3.5 3.5H10V1zM4 7h8v1H4V7zm0 2h8v1H4V9zm0 2h5v1H4v-1z\"/><\/svg><\/button>\n      <\/div>\n      <div class=\"more-wrap\" id=\"more-wrap\">\n        <button id=\"more-btn\" title=\"More\">&#x22EE;<\/button>\n        <div class=\"more-popover\" id=\"more-popover\">\n          <a class=\"more-open-link\" id=\"more-open-link\" href=\"#\" target=\"_blank\" rel=\"noopener\">Open in new tab &#x2197;<\/a>\n          <hr class=\"more-divider\">\n          <div class=\"more-row\">\n            <span class=\"more-row-label\">Speed<\/span>\n            <button id=\"speed-btn2\" title=\"Cycle speed\">/*INITIAL_SPEED*/x<\/button>\n          <\/div>\n          <label class=\"paced-toggle2\" id=\"paced-toggle-wrap2\" style=\"display:none\" title=\"Smooth out pauses — timing based on content length instead of real time\"><input type=\"checkbox\" id=\"toggle-paced2\"> Auto-paced<\/label>\n          <hr class=\"more-divider\">\n          <label><input type=\"checkbox\" id=\"toggle-thinking2\" /*CHECKED_THINKING*/> Thinking<\/label>\n          <label><input type=\"checkbox\" id=\"toggle-tools2\" /*CHECKED_TOOLS*/> Tools<\/label>\n          <hr class=\"more-divider\">\n          <div class=\"more-row\">\n            <span class=\"more-row-label\">Font<\/span>\n            <button class=\"font-size-cycle\" title=\"Cycle font size\">M<\/button>\n          <\/div>\n          <div id=\"fileSidebarToggle2Wrap\" style=\"display:none\">\n            <hr class=\"more-divider\">\n            <a class=\"file-sidebar-toggle2\" id=\"fileSidebarToggle2\" href=\"#\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 16 16\" fill=\"currentColor\"><path d=\"M3.5 0A1.5 1.5 0 0 0 2 1.5v13A1.5 1.5 0 0 0 3.5 16h9a1.5 1.5 0 0 0 1.5-1.5V4.5L10 0H3.5zM10 1l3.5 3.5H10V1zM4 7h8v1H4V7zm0 2h8v1H4V9zm0 2h5v1H4v-1z\"/><\/svg> Files<\/a>\n          <\/div>\n          <div id=\"more-chapters\" style=\"display:none\">\n            <hr class=\"more-divider\">\n            <div id=\"more-chapter-list\"><\/div>\n          <\/div>\n        <\/div>\n      <\/div>\n    <\/div>\n    <div class=\"progress-wrap\">\n      <div class=\"progress-bar\" id=\"progress-bar\">\n        <div class=\"progress-fill\" id=\"progress-fill\"><\/div>\n        <div class=\"progress-tooltip\" id=\"progress-tooltip\"><\/div>\n      <\/div>\n    <\/div>\n  <\/div>\n  <div id=\"splash\" class=\"splash\">\n    <div class=\"splash-title\">/*PAGE_TITLE*/<\/div>\n    <button class=\"splash-play\" id=\"splash-play\">&#9654;<\/button>\n  <\/div>\n  <div class=\"transcript\" id=\"transcript\" style=\"opacity:0.5\">Loading...<\/div>\n  <div class=\"file-sidebar\" id=\"fileSidebar\">\n  <div class=\"file-sidebar-header\">\n    <span class=\"file-sidebar-title\">Files <span class=\"file-sidebar-count\" id=\"fileSidebarCount\"><\/span><\/span>\n    <button class=\"file-sidebar-close\" id=\"fileSidebarClose\">&times;<\/button>\n  <\/div>\n  <div class=\"file-sidebar-list\" id=\"fileSidebarList\"><\/div>\n<\/div>\n<\/div>\n\n\x3cscript>\n(async function(){\"use strict\";async function bt(t){if(t.startsWith(\"[\")||t.startsWith(\"{\"))return JSON.parse(t);if(typeof DecompressionStream>\"u\")throw document.getElementById(\"transcript\").textContent=\"This replay uses compressed data, but your browser does not support DecompressionStream. Please use a modern browser (Chrome 80+, Firefox 113+, Safari 16.4+), or rebuild with --no-compress.\",new Error(\"DecompressionStream not supported\");const e=Uint8Array.from(atob(t),o=>o.charCodeAt(0)),n=new DecompressionStream(\"deflate\"),s=n.writable.getWriter();return s.write(e),s.close(),JSON.parse(await new Response(n.readable).text())}const b=await bt(\"/*TURNS_DATA*/\"),ot=await bt(\"/*BOOKMARKS_DATA*/\"),N=await bt(\"/*FILES_DATA*/\"),X=[.5,1,2,3,5],fe=600,ue=800,pe=1e4,F=20,he=5e3,me=600,Rt=/*HAS_REAL_TIMESTAMPS*/false;let ge=!1;function ve(){const t=b.length>0&&b[0].timestamp?new Date(b[0].timestamp).getTime():null,e=b.map(o=>o.timestamp?new Date(o.timestamp).getTime():0),n=b.map(o=>{let l=o.timestamp?new Date(o.timestamp).getTime():0;for(const r of o.blocks||[])r.timestamp&&(l=Math.max(l,new Date(r.timestamp).getTime())),r.tool_call?.resultTimestamp&&(l=Math.max(l,new Date(r.tool_call.resultTimestamp).getTime()));return l}),s=t!=null&&n.length?n[n.length-1]-t:0;return{start:t,starts:e,ends:n,total:s}}function be(){let t=0;const e=[],n=[];for(const s of b){e.push(t),t+=500;for(const o of s.blocks||[]){const l=(o.text||\"\").length;t+=Math.min(Math.max(l*30,1e3),1e4)}n.push(t)}return{start:0,starts:e,ends:n,total:t}}const J=ve(),ke=be();let $=J.start,Ot=J.starts,Nt=J.ends,lt=J.total;function Ft(t){ge=t;const e=t?ke:J;$=e.start,Ot=e.starts,Nt=e.ends,lt=e.total,I=0,mt(),gt(),P()}function it(t){if(t<=0)return\"0:00\";const e=Math.round(t/1e3),n=Math.floor(e/3600),s=Math.floor(e%3600/60),o=e%60;return n>0?n+\":\"+String(s).padStart(2,\"0\")+\":\"+String(o).padStart(2,\"0\"):s+\":\"+String(o).padStart(2,\"0\")}const Wt=new Map;for(const t of ot)Wt.set(t.turn,t.label);const f=t=>document.querySelector(t),V=t=>document.querySelectorAll(t),A=f(\"#transcript\"),Z=f(\"#btn-play\"),we=f(\"#btn-prev\"),Le=f(\"#btn-next\"),ye=f(\"#btn-prev-turn\"),Se=f(\"#btn-next-turn\"),Te=f(\"#progress-fill\"),Ee=f(\"#progress-text\"),_=f(\"#progress-bar\"),Yt=f(\"#progress-tooltip\"),Ut=f(\"#speed-btn\"),jt=f(\"#speed-btn2\"),rt=f(\"#speed-wrap\"),kt=f(\"#speed-popover\"),wt=f(\"#filter-wrap\"),xe=f(\"#filter-btn\"),ct=f(\"#toggle-thinking\"),at=f(\"#toggle-tools\");let Lt=f(\"#toggle-paced\");const Ae=f(\"#toggle-thinking2\"),_e=f(\"#toggle-tools2\"),dt=f(\"#toggle-paced2\"),ft=f(\"#more-wrap\"),$e=f(\"#more-btn\"),G=f(\"#chapter-wrap\"),Me=f(\"#chapter-btn\"),Ce=f(\"#chapter-menu\"),Ie=f(\"#bar-title\"),Be=f(\".controls\"),yt=f(\"#splash\");let i=0,w=!1,St=null,M=/*INITIAL_SPEED*/1,T=null,E=null,C=0,W=null,Tt=!1,z=null,I=0;function v(t){const e=document.createElement(\"div\");return e.textContent=t,e.innerHTML}function Et(t){if(!t)return\"\";const e=[],s=t.replace(/```([^\\n]*)\\n([\\s\\S]*?)```/g,(r,a,p)=>{const u=e.length;return e.push(`<pre><code${a?` class=\"language-${v(a)}\"`:\"\"}>${v(p.replace(/\\n$/,\"\"))}<\/code><\/pre>`),`\\0CB${u}\\0`}).split(`\n`);let o=\"\",l=null;for(let r=0;r<s.length;r++){let a=s[r];const p=a.match(/^\\x00CB(\\d+)\\x00$/);if(p){l&&(o+=`<\/${l}>`,l=null),o+=e[parseInt(p[1])];continue}if(/^---+$/.test(a.trim())){l&&(o+=`<\/${l}>`,l=null),o+=\"<hr>\";continue}const u=a.match(/^(#{1,4})\\s+(.+)$/);if(u){l&&(o+=`<\/${l}>`,l=null);const h=Math.min(u[1].length+2,6);o+=`<h${h}>${Q(v(u[2]))}<\/h${h}>`;continue}const d=a.match(/^(\\s*)[-*]\\s+(.+)$/);if(d){l!==\"ul\"&&(l&&(o+=`<\/${l}>`),o+=\"<ul>\",l=\"ul\"),o+=`<li>${Q(v(d[2]))}<\/li>`;continue}const c=a.match(/^(\\s*)\\d+\\.\\s+(.+)$/);if(c){l!==\"ol\"&&(l&&(o+=`<\/${l}>`),o+=\"<ol>\",l=\"ol\"),o+=`<li>${Q(v(c[2]))}<\/li>`;continue}if(l&&a.trim()===\"\"&&(o+=`<\/${l}>`,l=null),a.trim().startsWith(\"|\")&&r+1<s.length&&/^\\|[\\s:-]+\\|/.test(s[r+1].trim())){l&&(o+=`<\/${l}>`,l=null);const h=L=>L.replace(/^\\||\\|$/g,\"\").split(\"|\").map(m=>Q(v(m.trim()))),g=h(a);r++;let k=[];for(;r+1<s.length&&s[r+1].trim().startsWith(\"|\");)r++,k.push(h(s[r]));o+=\"<table><thead><tr>\"+g.map(L=>`<th>${L}<\/th>`).join(\"\")+\"<\/tr><\/thead>\",k.length&&(o+=\"<tbody>\"+k.map(L=>\"<tr>\"+L.map(m=>`<td>${m}<\/td>`).join(\"\")+\"<\/tr>\").join(\"\")+\"<\/tbody>\"),o+=\"<\/table>\";continue}a.trim()===\"\"?o.length>0&&(o+=`\n`):o+=`<p>${Q(v(a))}<\/p>`}return l&&(o+=`<\/${l}>`),o}function Q(t){return t=t.replace(/`([^`]+)`/g,\"<code>$1<\/code>\"),t=t.replace(/\\*\\*(.+?)\\*\\*/g,\"<strong>$1<\/strong>\"),t=t.replace(/(?<!\\w)\\*([^*]+?)\\*(?!\\w)/g,\"<em>$1<\/em>\"),t=t.replace(/\\[([^\\]]+)\\]\\((https?:\\/\\/[^)]+)\\)/g,'<a href=\"$2\" target=\"_blank\" rel=\"noopener noreferrer\">$1<\/a>'),t}function De(t,e){if(!t)return\"\";const s=(typeof t==\"string\"?t:JSON.stringify(t)).replace(/\\n/g,\" \").trim();return s.length>e?s.slice(0,e)+\"...\":s}function qe(t){if(typeof t==\"string\")return v(t);try{return v(JSON.stringify(t,null,2))}catch{return v(String(t))}}function He(t){const e=t.name||\"\",n=t.input||{};if(e===\"Edit\"||e===\"Write\"||e===\"Read\")return n.file_path||\"\";if(e===\"Grep\"||e===\"Glob\"){const s=n.pattern||\"\";return n.path?s+\" in \"+n.path:s}return e===\"Bash\"?n.command||\"\":De(n,60)}function Pe(t){const e=t.name||\"\",n=t.input||{};if(e===\"Edit\"&&n.old_string!=null&&n.new_string!=null){const o=n.file_path||\"\",l=String(n.old_string).split(`\n`),r=String(n.new_string).split(`\n`);let a=`<div class=\"diff-view\"><div class=\"diff-file\">${v(o)}${n.replace_all?\" (replace all)\":\"\"}<\/div>`;const p=l.length,u=r.length,d=Array.from({length:p+1},()=>new Array(u+1).fill(0));for(let g=p-1;g>=0;g--)for(let k=u-1;k>=0;k--)d[g][k]=l[g]===r[k]?d[g+1][k+1]+1:Math.max(d[g+1][k],d[g][k+1]);let c=0,h=0;for(;c<p||h<u;)c<p&&h<u&&l[c]===r[h]?(a+=`<div class=\"diff-line-ctx\">${v(\"  \"+l[c])}<\/div>`,c++,h++):h<u&&(c>=p||d[c][h+1]>=d[c+1][h])?(a+=`<div class=\"diff-line-add\">${v(\"+ \"+r[h])}<\/div>`,h++):(a+=`<div class=\"diff-line-del\">${v(\"\\u2212 \"+l[c])}<\/div>`,c++);if(a+=\"<\/div>\",t.result!=null){const g=t.is_error?\" diff-result-error\":\"\";a+=`<div class=\"diff-result${g}\">${v(t.result)}<\/div>`}return a}if(e===\"Write\"&&n.content!=null){const o=n.file_path||\"\";let l=`<div class=\"diff-view\"><div class=\"diff-file\">${v(o)}<\/div><pre style=\"margin:0;background:none;border:none;padding:0;overflow:visible;\"><code>${v(n.content)}<\/code><\/pre><\/div>`;if(t.result!=null){const r=t.is_error?\" diff-result-error\":\"\";l+=`<div class=\"diff-result${r}\">${v(t.result)}<\/div>`}return l}let s=`<div class=\"tool-input\"><div class=\"tool-input-label\">Input<\/div>${qe(n)}<\/div>`;if(t.result!=null){const o=t.is_error?\" tool-result-error\":\"\";s+=`<div class=\"tool-result${o}\" data-type=\"result\"><div class=\"tool-result-label\">Result<\/div>${v(t.result)}<\/div>`}return s}function Kt(t){return t?t.split(`\n`).length:0}function Xt(t,e,n){return e<=n?t:`<div class=\"collapsible-wrap is-collapsed\">\n      <div class=\"collapsible-content\">${t}<\/div>\n      <div class=\"collapsible-fade\"><\/div>\n      <button class=\"collapsible-toggle\" onclick=\"toggleCollapsible(this)\">Show more (${e} lines)<\/button>\n    <\/div>`}window.toggleCollapsible=function(t){const e=t.closest(\".collapsible-wrap\"),n=e.classList.toggle(\"is-collapsed\"),s=e.querySelector(\".collapsible-content\").textContent.split(`\n`).length;t.textContent=n?`Show more (${s} lines)`:\"Show less\"};function Re(t){return t.toISOString().replace(\"T\",\" \").replace(/\\.\\d+Z$/,\" UTC\")}function B(){return Be.offsetHeight}function ut(t){for(const e of t.querySelectorAll(\".open\"))e.classList.remove(\"open\")}function Oe(){yt.classList.remove(\"hidden\")}function Y(){yt.classList.add(\"hidden\")}function Ne(){return!yt.classList.contains(\"hidden\")}function xt(t){return b.length>1?(t-1)/(b.length-1):t?1:0}function Jt(t){return Math.min(b.length,Math.round(t*(b.length-1))+1)}function y(){return A.querySelectorAll(\".turn\")}function At(t){for(const e of t.querySelectorAll(\".block-wrapper.block-hidden\"))e.classList.remove(\"block-hidden\")}function pt(t){for(const e of t.querySelectorAll(\".block-wrapper\"))e.classList.add(\"block-hidden\"),e.classList.remove(\"block-revealing\",\"block-active\")}function tt(){for(const t of A.querySelectorAll(\".bookmark-divider\")){const e=parseInt(t.dataset.turn,10);t.classList.toggle(\"visible\",e<=i)}}function Fe(){Ut.textContent=M+\"x\",jt.textContent=M+\"x\";for(const t of kt.querySelectorAll(\"button\"))t.classList.toggle(\"active\",parseFloat(t.dataset.speed)===M)}function Vt(t){M=t,Fe()}function We(t,e){const n=document.createElement(\"div\");n.className=\"turn\",n.dataset.index=t.index;let s=\"\",o=\"\",l=\"\";if(t.timestamp){const p=new Date(t.timestamp);if(l=Re(p),$!=null){const u=p.getTime()-$;o=it(u)}}const r=o||l?`<span class=\"turn-header-ts\" ${l?`title=\"${l}\"`:\"\"}>${o||l}<\/span>`:\"\",a=e??t.index;if(s+=`<div class=\"turn-header\" onclick=\"this.parentElement.classList.toggle('collapsed')\">\n      <span class=\"turn-header-chevron\">&#9660;<\/span>\n      <span class=\"turn-header-label\">#${a}<\/span>\n      ${r}\n    <\/div>`,s+='<div class=\"turn-body\">',t.user_text){const p=Kt(t.user_text),u=`<div class=\"user-text\">${Et(t.user_text)}<\/div>`;s+=`<div class=\"role-section role-user\">\n        <div class=\"role-label role-user-label\">/*USER_LABEL*/<\/div>\n        ${Xt(u,p,10)}\n      <\/div>`}if(t.system_events&&t.system_events.length){s+='<div class=\"role-section role-system\">',s+='<div class=\"role-label role-system-label\">System<\/div>';for(const p of t.system_events)s+=`<div class=\"bg-task-badge\">${v(p)}<\/div>`;s+=\"<\/div>\"}if(t.blocks.length>0){s+='<div class=\"role-section role-assistant\">',s+='<div class=\"role-label role-assistant-label\">/*ASSISTANT_LABEL*/<\/div>';const p=[];let u=[],d=0;for(const c of t.blocks)c.kind===\"tool_use\"&&c.tool_call?u.push(c):(u.length>0&&(p.push({type:\"tools\",blocks:u,blockIdx:d++}),u=[]),p.push({type:\"single\",block:c,blockIdx:d++}));u.length>0&&p.push({type:\"tools\",blocks:u,blockIdx:d++});for(const c of p){const h=\" block-hidden\";if(c.type===\"single\"){const g=c.block;if(g.kind===\"text\"){const k=Kt(g.text),L=`<div class=\"assistant-text\">${Et(g.text)}<\/div>`;s+=`<div class=\"block-wrapper${h}\" data-block-idx=\"${c.blockIdx}\">${Xt(L,k,15)}<\/div>`}else g.kind===\"thinking\"&&(s+=`<div class=\"block-wrapper${h}\" data-block-idx=\"${c.blockIdx}\"><div class=\"thinking-block\" data-type=\"thinking\">\n              <div class=\"thinking-header\" onclick=\"this.parentElement.classList.toggle('open')\">\n                <span class=\"thinking-chevron\">&#9654;<\/span> Thinking <span class=\"block-spinner\"><\/span>\n              <\/div>\n              <div class=\"thinking-body\">${Et(g.text)}<\/div>\n            <\/div><\/div>`)}else{const g=c.blocks.map(k=>{const L=k.tool_call,m=He(L),S=Pe(L);return`<div class=\"tool-block\" data-type=\"tool\">\n              <div class=\"tool-header\" onclick=\"this.parentElement.classList.toggle('open')\">\n                <span class=\"tool-indicator${L.is_error?\" tool-error\":\"\"}\"><\/span>\n                <span class=\"tool-name\">${v(L.name)}<\/span>\n                <span class=\"tool-args-preview\">${v(m)}<\/span>\n                <span class=\"block-spinner\"><\/span>\n                <span class=\"tool-chevron\">&#9654;<\/span>\n              <\/div>\n              <div class=\"tool-body\">${S}<\/div>\n            <\/div>`}).join(\"\");if(c.blocks.length<=4)s+=`<div class=\"block-wrapper${h}\" data-block-idx=\"${c.blockIdx}\">${g}<\/div>`;else{const k=c.blocks.map(S=>S.tool_call.name),L=[...new Set(k)].join(\", \"),m=c.blocks.some(S=>S.tool_call.is_error);s+=`<div class=\"block-wrapper${h}\" data-block-idx=\"${c.blockIdx}\"><div class=\"tool-group\" data-type=\"tool\">\n              <div class=\"tool-group-header\" onclick=\"this.parentElement.classList.toggle('open')\">\n                <span class=\"tool-group-chevron\">&#9654;<\/span>\n                ${m?'<span class=\"tool-indicator tool-error\" style=\"display:inline-block;margin-right:4px;\"><\/span>':\"\"}${c.blocks.length} tool calls\n                <span class=\"tool-group-names\">${v(L)}<\/span>\n                <span class=\"block-spinner\"><\/span>\n              <\/div>\n              <div class=\"tool-group-body\">${g}<\/div>\n            <\/div><\/div>`}}}s+=\"<\/div>\"}return s+=\"<\/div>\",n.innerHTML=s,n}function Ye(){for(let t=0;t<b.length;t++){const e=b[t],n=Wt.get(e.index);if(n){const o=document.createElement(\"div\");o.className=\"bookmark-divider\",o.dataset.turn=e.index,o.textContent=n,A.appendChild(o)}const s=We(e,t+1);A.appendChild(s)}}function ht(){const t=ct.checked,e=at.checked;for(const n of V('[data-type=\"thinking\"]'))n.style.display=t?\"\":\"none\";for(const n of V('[data-type=\"tool\"]'))n.style.display=e?\"\":\"none\"}function D(){W&&(cancelAnimationFrame(W),W=null)}function Ue(t,e,n){D();const s=window.scrollY,o=t-s;if(Math.abs(o)<2){n&&n();return}const l=performance.now(),r=!!n;function a(p){if(r&&!w){D();return}const u=p-l,d=Math.min(u/e,1),c=d<.5?2*d*d:-1+(4-2*d)*d;window.scrollTo(0,s+o*c),d<1?W=requestAnimationFrame(a):(W=null,n&&n())}W=requestAnimationFrame(a)}function je(t){C=Date.now()+2e3,requestAnimationFrame(()=>{requestAnimationFrame(()=>{const e=t.getBoundingClientRect().bottom+window.scrollY,n=B(),s=window.innerHeight-n,o=Math.max(0,e-s+F),l=Math.abs(o-window.scrollY);if(l<2)return;const r=Math.min(me+l*.3,1500);Ue(o,r)})})}function q(t,{skipScroll:e=!1,hideActiveBlocks:n=!1}={}){i=Math.min(t,b.length);const s=y();for(let o=0;o<s.length;o++){const l=s[o];o<i?(l.classList.add(\"visible\"),w||(n&&o===i-1?pt(l):At(l))):(ut(l),l.classList.remove(\"visible\"),pt(l))}if(tt(),P(),nt(i-1),!e&&i>0){const o=s[i-1];o&&je(o)}}function Zt(t,e){let n=0;const s=100;let o=null;function l(){if(t-n*M<=0){e();return}n+=s,o=setTimeout(l,s)}return l(),function(){clearTimeout(o)}}function _t(t,e,n){const s=b[t];if(!s)return e(),function(){};const o=y()[t];if(!o)return e(),function(){};const l=o.querySelectorAll(\".block-wrapper\");if(l.length===0)return e(),function(){};const r=[];let a=[];for(const m of s.blocks)m.kind===\"tool_use\"&&m.tool_call?a.push(m):(a.length>0&&(r.push({type:\"tools\",blocks:a}),a=[]),r.push({type:\"single\",block:m}));a.length>0&&r.push({type:\"tools\",blocks:a});function p(m){return m.type===\"single\"?m.block.timestamp||null:m.blocks[0]&&m.blocks[0].timestamp||null}const u=[0];for(let m=1;m<r.length&&m<l.length;m++){const S=p(r[m]),O=p(r[m-1]);let st;S&&O?st=new Date(S).getTime()-new Date(O).getTime():st=ue,u.push(Math.min(Math.max(st,fe),pe))}let d=!1,c=null,h=n||0;function g(m){const S=l[m];if(!S)return;const O=o.querySelector(\".block-active\");O&&O.classList.remove(\"block-active\"),S.classList.remove(\"block-hidden\"),S.classList.add(\"block-revealing\"),S.classList.add(\"block-active\"),requestAnimationFrame(()=>{const st=B(),ae=window.innerHeight-st,de=S.getBoundingClientRect();if(de.bottom>ae){D();const Ze=de.bottom+window.scrollY-ae+20;window.scrollTo({top:Ze,behavior:m===0?\"smooth\":\"instant\"})}})}function k(){if(d||h>=u.length){if(!d){for(const O of o.querySelectorAll(\".block-active\"))O.classList.remove(\"block-active\");E=null,e()}return}const m=h,S=u[m];if(h++,S===0){g(m),k();return}c=Zt(S,()=>{d||(c=null,g(m),k())})}function L(){d||(d=!0,c&&(c(),c=null),E={turnIndex:t,blockIdx:h})}return k(),L}function et(){T=Zt(he,()=>{w&&(T=null,Gt())})}function Gt(){if(!w)return;if(i>=b.length){x();return}const t=i===0;if(q(i+1,{skipScroll:!0}),t){const s=y()[0];if(s){const o=B(),l=window.innerHeight-o,r=s.getBoundingClientRect().bottom+window.scrollY;window.scrollTo({top:Math.max(0,r-l+F),behavior:\"instant\"})}}const e=y()[i-1];if(!e){x();return}if(e.querySelectorAll(\".block-wrapper\").length===0){U(e),et();return}T=_t(i-1,()=>{T=null,w&&et()})}function $t(){if(Y(),i>=b.length){const t=y()[b.length-1];if(t&&t.querySelectorAll(\".block-wrapper.block-hidden\").length>0)i=b.length;else{i=0,E=null;for(const n of A.children)ut(n),n.classList.remove(\"visible\");for(const n of A.querySelectorAll(\".block-wrapper\"))n.classList.add(\"block-hidden\"),n.classList.remove(\"block-revealing\")}}if(w=!0,te(),Z.innerHTML=\"&#9646;&#9646;\",Z.classList.add(\"active\"),i>0){const t=y()[i-1];t&&U(t)}if(E){const t=E;E=null,T=_t(t.turnIndex,()=>{T=null,w&&et()},t.blockIdx);return}if(i>0){const t=y()[i-1];if(t){const e=t.querySelectorAll(\".block-wrapper:not(.block-hidden)\").length,n=t.querySelectorAll(\".block-wrapper\").length;if(e<n){T=_t(i-1,()=>{T=null,w&&et()},e);return}if(e>0&&n>0){et();return}}}Gt()}function x(){w=!1,ee(),D(),Z.innerHTML=\"&#9654;\",Z.classList.remove(\"active\"),St&&(clearTimeout(St),St=null),T&&(T(),T=null)}function H(t,e){w&&x(),E=null,t<=0?(q(0),Oe()):(Y(),q(Math.min(t,b.length),e))}function Mt(t){requestAnimationFrame(()=>{const e=B(),n=window.innerHeight-e,s=t.getBoundingClientRect();if(s.bottom>n){D();const o=s.bottom+window.scrollY-n+F;window.scrollTo({top:o,behavior:\"smooth\"})}else if(s.top<0){D();const o=s.top+window.scrollY-F;window.scrollTo({top:Math.max(0,o),behavior:\"smooth\"})}})}function U(t){requestAnimationFrame(()=>{const e=B(),n=window.innerHeight-e,s=t.getBoundingClientRect().bottom+window.scrollY,o=Math.max(0,s-n+F);D(),window.scrollTo({top:o,behavior:\"smooth\"})})}function zt(){if(w&&x(),E=null,C=Date.now()+2e3,i===0){Y(),i=1;const n=y();n[0]&&(n[0].classList.add(\"visible\"),pt(n[0]),U(n[0])),tt(),P(),nt(0);return}const t=y()[i-1];if(!t)return;const e=t.querySelectorAll(\".block-wrapper.block-hidden\");if(e.length>0){const n=e[0],s=t.querySelector(\".block-active\");s&&s.classList.remove(\"block-active\"),n.classList.remove(\"block-hidden\"),n.classList.add(\"block-revealing\",\"block-active\"),gt(),Mt(n)}else if(i<b.length){const n=t.querySelector(\".block-active\");n&&n.classList.remove(\"block-active\"),i++;const o=y()[i-1];o&&(o.classList.add(\"visible\"),pt(o),Mt(o)),tt(),P(),nt(i-1)}}function Qt(){w&&x(),E=null,C=Date.now()+2e3;const t=i>0?y()[i-1]:null;if(t){const e=t.querySelectorAll(\".block-wrapper:not(.block-hidden)\");if(e.length>0){const n=e[e.length-1];ut(n),n.classList.add(\"block-hidden\"),n.classList.remove(\"block-revealing\",\"block-active\");const s=t.querySelectorAll(\".block-wrapper:not(.block-hidden)\");s.length>0?(s[s.length-1].classList.add(\"block-active\"),U(s[s.length-1])):U(t),gt();return}}if(i<=1)H(0);else{i--;const e=y(),n=e[i];n&&(ut(n),n.classList.remove(\"visible\"));const s=e[i-1];s&&(At(s),U(s)),tt(),P(),nt(i-1)}}function P(){const t=Math.max(0,xt(i)*100);Te.style.width=t+\"%\",gt(),w&&te();for(const n of _.querySelectorAll(\".turn-dot\")){const s=parseInt(n.dataset.turn,10);n.classList.toggle(\"reached\",s<=i)}let e=null;for(const n of _.querySelectorAll(\".bookmark-dot\")){const o=parseInt(n.dataset.turn,10)<=i;n.classList.toggle(\"reached\",o),n.classList.remove(\"active\"),o&&(e=n)}e&&e.classList.add(\"active\")}function mt(){Ee.textContent=it(I)+\" / \"+it(lt)}function te(){z||(z=setInterval(()=>{I=Math.min(I+1e3*M,lt),mt(),I>=lt&&ee()},1e3))}function gt(){if($==null||i<=0){I=0,mt();return}const t=i-1,e=y()[t];if(!e)return;const n=e.querySelectorAll(\".block-wrapper\").length,s=e.querySelectorAll(\".block-wrapper:not(.block-hidden)\").length,o=Ot[t]-$,l=Nt[t]-$,r=n>0?s/n:0;I=Math.round(o+(l-o)*r),mt()}function ee(){z&&(clearInterval(z),z=null)}function nt(t){for(const n of V(\".turn.active\"))n.classList.remove(\"active\");const e=y();t>=0&&t<e.length&&e[t].classList.add(\"active\")}function Ct(t){const e=_.getBoundingClientRect(),n=Math.max(0,Math.min(1,(t-e.left)/e.width)),s=Jt(n);s<=1&&n<.05?H(0):H(Math.max(1,s),{hideActiveBlocks:!0})}function Ke(){if(w||Date.now()<C||Ne())return;const t=y();if(!t.length)return;const e=window.innerHeight/2;let n=-1;for(let s=0;s<t.length;s++)t[s].getBoundingClientRect().top<e&&(n=s);if(n>=0){const s=n+1;if(s!==i){if(s>i){i=s;for(let o=0;o<t.length;o++)t[o].classList.toggle(\"visible\",o<i),o<i&&At(t[o]);tt()}else i=s;P(),nt(i-1)}}}const ne=[rt,wt,G,ft].filter(Boolean);function R(t){for(const e of ne)t&&e===t||e.classList.remove(\"open\")}document.addEventListener(\"click\",t=>{for(const e of ne)if(e.classList.contains(\"open\")&&e.contains(t.target))return;R()}),window.addEventListener(\"blur\",()=>{R()}),Z.addEventListener(\"click\",()=>w?x():$t()),Le.addEventListener(\"click\",zt),we.addEventListener(\"click\",Qt),Se.addEventListener(\"click\",()=>vt(1)),ye.addEventListener(\"click\",()=>vt(-1)),Ut.addEventListener(\"click\",t=>{t.stopPropagation();const e=rt.classList.contains(\"open\");R(),e||rt.classList.add(\"open\")});for(let t=X.length-1;t>=0;t--){const e=X[t],n=document.createElement(\"button\");n.textContent=e+\"x\",n.dataset.speed=e,e===M&&n.classList.add(\"active\"),n.addEventListener(\"click\",s=>{s.stopPropagation(),Vt(e),rt.classList.remove(\"open\")}),kt.appendChild(n)}if(Rt){const t=document.createElement(\"label\");t.className=\"paced-toggle\",t.id=\"paced-toggle-wrap\",t.title=\"Smooth out pauses \\u2014 timing based on content length instead of real time\",t.innerHTML='<input type=\"checkbox\" id=\"toggle-paced\"> Auto-paced',kt.appendChild(t);const e=t.querySelector(\"input\");e.addEventListener(\"change\",()=>{dt.checked=e.checked,Ft(e.checked)}),Lt=e}xe.addEventListener(\"click\",t=>{t.stopPropagation();const e=wt.classList.contains(\"open\");R(),e||wt.classList.add(\"open\")}),ct.addEventListener(\"change\",ht),at.addEventListener(\"change\",ht);const It=[\"small\",\"normal\",\"large\"],se={small:\"11px\",normal:\"13px\",large:\"15px\"},Xe={small:\"S\",normal:\"M\",large:\"L\"};let Bt=/*FONT_SIZE_NAME*/\"normal\";function oe(t){Bt=t,document.body.style.setProperty(\"--font-size\",se[t]||se.normal);for(const e of V(\".font-size-cycle\"))e.textContent=Xe[t]||\"M\"}oe(Bt);for(const t of V(\".font-size-cycle\"))t.addEventListener(\"click\",e=>{e.stopPropagation();const n=It.indexOf(Bt);oe(It[(n+1)%It.length])});Rt&&(f(\"#paced-toggle-wrap2\").style.display=\"\"),dt.addEventListener(\"change\",()=>{Lt&&(Lt.checked=dt.checked),Ft(dt.checked)});const Je=f(\"#more-open-link\");$e.addEventListener(\"click\",t=>{t.stopPropagation();const e=ft.classList.contains(\"open\");if(R(),!e){const n=f(\".turn.active\"),s=n?parseInt(n.dataset.index,10):i;Je.href=location.href.replace(/#.*/,\"\")+\"#turn=\"+s,ft.classList.add(\"open\")}}),jt.addEventListener(\"click\",()=>{const t=X.indexOf(M);Vt(X[(t+1)%X.length])});function le(t,e){e.addEventListener(\"change\",()=>{t.checked=e.checked,ht()}),t.addEventListener(\"change\",()=>{e.checked=t.checked})}le(ct,Ae),le(at,_e),_.addEventListener(\"click\",t=>Ct(t.clientX)),_.addEventListener(\"touchstart\",t=>{t.preventDefault(),Ct(t.touches[0].clientX)},{passive:!1}),_.addEventListener(\"touchmove\",t=>{t.preventDefault(),Ct(t.touches[0].clientX)},{passive:!1}),_.addEventListener(\"mousemove\",t=>{const e=_.getBoundingClientRect(),n=Math.max(0,Math.min(1,(t.clientX-e.left)/e.width)),s=Jt(n),o=b[s-1];let l=`#${s}`;if(o&&o.timestamp&&$!=null){const a=new Date(o.timestamp).getTime()-$;l+=` \\xB7 ${it(a)}`}Yt.textContent=l;const r=Math.max(20,Math.min(e.width-20,t.clientX-e.left));Yt.style.left=r+\"px\"}),A.addEventListener(\"click\",t=>{w&&(t.target.closest(\".turn-header\")||t.target.closest(\".thinking-header\")||t.target.closest(\".tool-header\")||t.target.closest(\".tool-group-header\")||t.target.closest(\".collapsible-toggle\"))&&x()});function vt(t){w&&x(),E=null,C=Date.now()+2e3;const e=t>0?Math.min(i+1,b.length):Math.max(i-1,0);H(e,{hideActiveBlocks:!0})}let j=null;function ie(t){w&&x(),E=null,C=Date.now()+2e3;const e=ct.checked,n=at.checked,s=[],o=y();for(const d of o)for(const c of d.querySelectorAll(\".block-wrapper\")){if(e)for(const h of c.querySelectorAll('[data-type=\"thinking\"]'))s.push(h);if(n)for(const h of c.querySelectorAll('[data-type=\"tool\"]'))s.push(h)}if(s.length===0)return;let l=-1;if(j&&(l=s.indexOf(j)),l<0&&i>0){const d=o[i-1];if(d){for(let c=s.length-1;c>=0;c--)if(d.contains(s[c])){l=c;break}if(l<0)for(let c=s.length-1;c>=0;c--){const h=s[c].closest(\".turn\");if((h?parseInt(h.dataset.index,10):0)<=i){l=c;break}}}}let r;t>0?r=l<0?0:Math.min(l+1,s.length-1):r=l<0?s.length-1:Math.max(l-1,0);const a=s[r],p=a.closest(\".turn\");if(p){const d=parseInt(p.dataset.index,10);d!==i&&(Y(),q(d,{skipScroll:!0}))}j&&j!==a&&j.classList.remove(\"open\"),a.classList.add(\"open\"),j=a;const u=a.closest(\".block-wrapper\");if(u){const d=A.querySelector(\".block-active\");d&&d.classList.remove(\"block-active\"),u.classList.add(\"block-active\")}Mt(a)}document.addEventListener(\"keydown\",t=>{if(t.target.tagName!==\"INPUT\"){if((t.key===\" \"||t.key===\"k\")&&(t.preventDefault(),w?x():$t()),t.shiftKey&&(t.key===\"ArrowRight\"||t.key===\"L\")){t.preventDefault(),vt(1);return}if(t.shiftKey&&(t.key===\"ArrowLeft\"||t.key===\"H\")){t.preventDefault(),vt(-1);return}(t.key===\"ArrowRight\"||t.key===\"l\")&&(t.preventDefault(),zt()),(t.key===\"ArrowLeft\"||t.key===\"h\")&&(t.preventDefault(),Qt()),t.key===\"t\"&&(t.preventDefault(),ie(1)),t.key===\"T\"&&(t.preventDefault(),ie(-1))}});let Dt=!1;try{Dt=window!==window.top}catch{Dt=!0}Dt&&(document.body.classList.add(\"in-iframe\"),Ie.addEventListener(\"click\",()=>{const t=f(\".turn.active\"),e=t?parseInt(t.dataset.index,10):i,n=location.href.replace(/#.*/,\"\")+\"#turn=\"+e;window.open(n,\"_blank\")})),window.addEventListener(\"scroll\",()=>{Tt||(Tt=!0,requestAnimationFrame(()=>{Ke(),Tt=!1}))},{passive:!0});for(let t=0;t<b.length;t++){const e=document.createElement(\"div\");e.className=\"turn-dot\",e.dataset.turn=t+1,e.style.left=xt(t+1)*100+\"%\",_.appendChild(e)}if(ot.length>0){G.style.display=\"\";for(const n of ot){const s=document.createElement(\"div\");s.className=\"bookmark-dot\",s.dataset.turn=n.turn,s.style.left=xt(n.turn)*100+\"%\",_.appendChild(s)}const t=f(\"#more-chapters\"),e=f(\"#more-chapter-list\");t.style.display=\"\";for(const n of ot){const s=document.createElement(\"div\");s.className=\"chapter-item\",s.title=n.label,s.innerHTML=`<span class=\"chapter-item-turn\">#${n.turn}<\/span><span class=\"chapter-item-label\">${v(n.label)}<\/span>`,s.addEventListener(\"click\",()=>{H(n.turn,{hideActiveBlocks:!0}),G.classList.remove(\"open\")}),Ce.appendChild(s);const o=document.createElement(\"div\");o.className=\"chapter-item\",o.innerHTML=s.innerHTML,o.addEventListener(\"click\",()=>{H(n.turn,{hideActiveBlocks:!0}),ft.classList.remove(\"open\")}),e.appendChild(o)}Me.addEventListener(\"click\",n=>{n.stopPropagation();const s=G.classList.contains(\"open\");R(),s||G.classList.add(\"open\")})}A.textContent=\"\",A.style.opacity=\"\",Ye(),ht();const qt=location.hash.match(/turn=(\\d+)(r)?/);if(qt){const t=Math.min(parseInt(qt[1],10),b.length),e=qt[2]===\"r\";t>0&&(Y(),e?(q(t,{hideActiveBlocks:!1,skipScroll:!0}),C=Date.now()+2e3,requestAnimationFrame(()=>{requestAnimationFrame(()=>{const n=y()[t-1];if(n){const s=B(),o=window.innerHeight-s,r=(n.querySelector(\".block-wrapper:last-child\")||n).getBoundingClientRect().bottom+window.scrollY;window.scrollTo(0,Math.max(0,r-o+F))}})})):q(t,{hideActiveBlocks:!0}))}P();let re=location.hash;window.addEventListener(\"hashchange\",()=>{if(location.hash===re)return;re=location.hash;const t=location.hash.match(/turn=(\\d+)(r)?/);if(!t)return;const e=Math.min(parseInt(t[1],10),b.length),n=t[2]===\"r\";e>0&&(x(),Y(),q(e,{hideActiveBlocks:!n}))}),f(\"#splash-play\").addEventListener(\"click\",()=>$t());const K=f(\"#fileSidebar\"),Ht=f(\"#fileSidebarList\"),ce=f(\"#fileSidebarToggle\"),Ve=f(\"#fileSidebarCount\"),Ge={Write:\"\\u271A\",Edit:\"\\u270E\",Read:\"\\u{1F441}\",Bash:\"$\",Grep:\"\\u2315\",Glob:\"\\u25C9\"};if(N.length>0){const t=Math.max(...N.map(o=>o.name.length)),e=Math.min(260,Math.max(180,t*8+70));K.style.width=e+\"px\";const n=document.createElement(\"style\");n.textContent=\"body.sidebar-open .transcript { margin-right: \"+e+\"px; }\",document.head.appendChild(n),ce.style.display=\"\",f(\"#fileSidebarToggle2Wrap\").style.display=\"\",Ve.textContent=\"(\"+N.length+\")\";let s=\"\";for(const o of N){const l=new Set(o.refs.map(d=>d.tool)),r=l.has(\"Write\")?\"file-created\":l.has(\"Edit\")?\"file-modified\":\"file-read\",a=o.refs.length>1?`<span class=\"file-entry-badge\">${o.refs.length}<\/span>`:\"\";s+=`<div class=\"file-entry\" data-path=\"${v(o.path)}\">`;const p=o.relPath||o.path,u=p.includes(\"/\")?p.slice(0,p.lastIndexOf(\"/\")):\"\";s+=`<div class=\"file-entry-header\"><span class=\"file-entry-chevron\">&#9654;<\/span><span class=\"file-entry-name ${r}\" title=\"${v(o.path)}\"><span class=\"file-entry-name-main\">${v(o.name)}<\/span>${u?`<span class=\"file-entry-name-path\">${v(u)}<\/span>`:\"\"}<\/span>${a}<\/div>`,s+='<div class=\"file-entry-refs\">';for(const d of o.refs)s+=`<a class=\"file-entry-ref\" data-turn=\"${d.turn}\" data-block=\"${d.block}\"><span class=\"ref-tool\">${d.tool}<\/span> in turn ${d.turn}<\/a>`;s+=\"<\/div><\/div>\"}Ht.innerHTML=s,Ht.addEventListener(\"click\",o=>{const l=o.target.closest(\".file-entry-header\");if(l){l.closest(\".file-entry\").classList.toggle(\"expanded\");return}const r=o.target.closest(\".file-entry-ref\");if(r){const a=parseInt(r.dataset.turn),p=parseInt(r.dataset.block);if(a>0){H(a,{hideActiveBlocks:!1}),C=Date.now()+2e3;const u=r.closest(\".file-entry\")?.dataset.path,d=r.querySelector(\".ref-tool\")?.textContent;if(u){const c=y()[a-1];if(c){const h=u.split(\"/\").pop();for(const g of c.querySelectorAll(\".tool-block\")){const k=g.querySelector(\".tool-name\"),L=g.querySelector(\".tool-args-preview\");if(k&&L&&k.textContent===d&&L.textContent.includes(h)){const m=g.closest(\".tool-group\");m&&m.classList.add(\"open\"),g.classList.add(\"open\");break}}}}window.innerWidth<=700&&K.classList.remove(\"open\")}}})}function Pt(t){const e=t!==void 0?t:!K.classList.contains(\"open\");e&&(K.style.bottom=B()+\"px\"),K.classList.toggle(\"open\",e),document.body.classList.toggle(\"sidebar-open\",e)}if(ce.addEventListener(\"click\",()=>Pt()),f(\"#fileSidebarToggle2\").addEventListener(\"click\",t=>{t.preventDefault(),R(),Pt()}),f(\"#fileSidebarClose\").addEventListener(\"click\",()=>Pt(!1)),N.length>0){const t=new Map;for(const n of N)for(const s of n.refs)t.has(s.turn)||t.set(s.turn,new Set),t.get(s.turn).add(n.path);let e=-1;setInterval(()=>{if(!K.classList.contains(\"open\")||i===e)return;e=i;const n=t.get(i)||new Set;for(const s of Ht.querySelectorAll(\".file-entry-header\")){const o=s.closest(\".file-entry\").dataset.path;s.classList.toggle(\"active\",n.has(o))}},300)}document.body.dataset.ready=\"1\"})();\n<\/script>\n<\/body>\n<\/html>\n";
+const PLAYER_TEMPLATE = "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n<link rel=\"icon\" href=\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='14' fill='none' stroke='%23bb9af7' stroke-width='2'/><polygon points='12,8 12,24 24,16' fill='%23bb9af7'/><\/svg>\">\n<title>/*PAGE_TITLE*/<\/title>\n<meta name=\"theme-color\" content=\"/*THEME_BG*/\">\n<meta property=\"og:title\" content=\"/*PAGE_TITLE*/\">\n<meta property=\"og:description\" content=\"/*PAGE_DESCRIPTION*/\">\n<meta property=\"og:type\" content=\"website\">\n<meta property=\"og:image\" content=\"/*OG_IMAGE*/\">\n<meta name=\"twitter:card\" content=\"summary_large_image\">\n<meta name=\"twitter:title\" content=\"/*PAGE_TITLE*/\">\n<meta name=\"twitter:description\" content=\"/*PAGE_DESCRIPTION*/\">\n<meta name=\"twitter:image\" content=\"/*OG_IMAGE*/\">\n<style>\n/*THEME_CSS*/ *{margin:0;padding:0;box-sizing:border-box}body{background:var(--bg);color:var(--text);font-family:SF Mono,Cascadia Code,Fira Code,JetBrains Mono,Consolas,monospace;font-size:var(--font-size, /*FONT_SIZE*/13px);line-height:1.6;-webkit-text-size-adjust:100%;touch-action:manipulation}.container{max-width:960px;margin:0 auto;padding:0}.controls{position:fixed;bottom:0;left:50%;transform:translate(-50%);width:100%;max-width:960px;z-index:100;background:var(--bg-surface);border-top:1px solid var(--border);display:flex;flex-direction:column-reverse}.controls-row{display:flex;align-items:center;gap:8px 0;padding:8px;flex-wrap:wrap}.controls button{background:var(--bg-hover);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 10px;font-family:inherit;font-size:14px;cursor:pointer;transition:background .15s;flex-shrink:0;height:34px;min-width:34px;display:inline-flex;align-items:center;justify-content:center}.controls button:hover{background:var(--border)}#btn-play{width:36px}#btn-prev,#btn-next{min-width:30px;width:30px;font-size:13px}#btn-prev-turn,#btn-next-turn{min-width:26px;width:26px;font-size:10px;padding:2px}.nav-group{display:flex;align-items:center;gap:3px}.controls button.active{background:var(--accent-dim);border-color:var(--accent)}.bar-title{font-size:13px;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;text-decoration:none;margin:0 0 0 12px;flex:1;min-width:0}@media(max-width:480px){.bar-title{display:none}.nav-group{margin-right:auto}}body.in-iframe .bar-title{cursor:pointer}body.in-iframe .bar-title:after{content:\" \\2197\";font-size:9px}body.in-iframe .bar-title:hover{color:var(--text)}.progress-wrap{width:100%;display:flex;align-items:center;gap:8px;padding:0 12px 8px}.progress-bar{flex:1;height:4px;background:var(--bg);border-radius:2px;cursor:pointer;position:relative;transition:height .15s}.progress-bar:before{content:\"\";position:absolute;inset:-12px 0}.progress-bar:hover{height:6px}.progress-fill{height:100%;background:var(--accent);border-radius:2px;transition:width .2s}.progress-tooltip{position:absolute;bottom:12px;transform:translate(-50%);background:var(--bg-surface);border:1px solid var(--border);border-radius:4px;padding:3px 8px;font-size:11px;color:var(--text);white-space:nowrap;pointer-events:none;opacity:0;transition:opacity .15s;z-index:10}.progress-bar:hover .progress-tooltip{opacity:1}.progress-text{font-size:11px;color:var(--text-dim);white-space:nowrap;font-variant-numeric:tabular-nums;margin-left:12px}.speed-wrap{position:relative}.paced-toggle{display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-dim);cursor:pointer;white-space:nowrap;user-select:none;padding:4px 12px;border-top:1px solid var(--border);margin-top:2px}.controls-secondary button{width:34px;min-width:34px}.speed-wrap button#speed-btn{font-variant-numeric:tabular-nums;font-size:12px;letter-spacing:-.5px}.speed-popover{display:none;position:absolute;bottom:calc(100% + 6px);left:50%;transform:translate(-50%);background:var(--bg-surface);border:1px solid var(--border);border-radius:6px;padding:4px 0;z-index:200;box-shadow:0 4px 12px #0000004d;min-width:60px}.speed-wrap.open .speed-popover{display:block}.speed-popover button{display:block;width:100%;background:none;border:none;color:var(--text-dim);font-family:inherit;font-size:13px;font-variant-numeric:tabular-nums;padding:6px 16px;cursor:pointer;text-align:center;white-space:nowrap}.speed-popover button:hover{background:var(--bg-hover);color:var(--text)}.speed-popover button.active{color:var(--accent);font-weight:600}.filter-wrap{position:relative}.filter-popover{display:none;position:absolute;bottom:calc(100% + 6px);right:0;background:var(--bg-surface);border:1px solid var(--border);border-radius:6px;padding:8px 12px;z-index:200;box-shadow:0 4px 12px #0000004d;min-width:140px}.filter-wrap.open .filter-popover{display:block}.filter-popover label{display:flex;align-items:center;gap:6px;color:var(--text-dim);cursor:pointer;user-select:none;font-size:12px;padding:4px 0;white-space:nowrap}.filter-popover label:hover{color:var(--text)}.filter-popover input[type=checkbox]{accent-color:var(--accent)}.font-size-row{display:flex;align-items:center;gap:8px;padding:4px 0;border-top:1px solid var(--border);margin-top:4px;font-size:12px;color:var(--text-dim)}.font-size-row-label{min-width:50px}.font-size-cycle{background:var(--bg-hover);border:1px solid var(--border);color:var(--text-dim);border-radius:3px;cursor:pointer;padding:2px 8px;font-size:11px;font-family:inherit;min-width:28px;text-align:center}.font-size-cycle:hover{color:var(--text);border-color:var(--accent-dim)}.controls-secondary{display:flex;align-items:center;gap:4px;margin-left:6px;flex-wrap:wrap;justify-content:center}.more-wrap{position:relative;display:none;margin-left:6px}@media(max-width:600px){.more-wrap{display:block}}.more-popover{display:none;position:absolute;bottom:calc(100% + 6px);right:0;background:var(--bg-surface);border:1px solid var(--border);border-radius:6px;padding:8px 12px;z-index:200;box-shadow:0 4px 12px #0000004d;min-width:180px;max-height:40vh;overflow-y:auto}.more-wrap.open .more-popover{display:block}.more-open-link{display:none;font-size:12px;color:var(--text-dim);text-decoration:none;padding:4px 0;white-space:nowrap}.more-open-link+hr.more-divider{display:none}body.in-iframe .more-open-link{display:block}body.in-iframe .more-open-link+hr.more-divider{display:block}.more-open-link:hover{color:var(--text)}.more-popover label{display:flex;align-items:center;gap:6px;color:var(--text-dim);cursor:pointer;user-select:none;font-size:12px;padding:4px 0;white-space:nowrap}.more-popover label:hover{color:var(--text)}.more-popover input[type=checkbox]{accent-color:var(--accent)}.more-popover .more-row{display:flex;align-items:center;gap:8px;padding:4px 0;font-size:12px;color:var(--text-dim)}.more-popover .more-row-label{min-width:50px}.more-divider{border:none;border-top:1px solid var(--border);margin:4px 0}#more-btn{background:none!important;border:none!important;font-size:16px;font-weight:700;min-width:20px;width:20px;padding:0;justify-content:flex-end}#chapter-btn{font-size:16px}@media(max-width:600px){body:not(.in-iframe) .controls-secondary{display:none}body:not(.in-iframe) .chapter-wrap{display:none!important}}@media(max-width:600px){body.in-iframe .controls-secondary{display:none}body.in-iframe .chapter-wrap{display:none!important}}.transcript{padding:calc(100vh - 80px) 16px 100vh;min-height:100vh}.turn{margin-bottom:24px;opacity:.25;transition:opacity .4s}.turn.visible{opacity:.35}.turn.visible.active{opacity:1}.user-msg{margin-bottom:8px}.user-prompt{color:var(--accent);font-weight:600}.user-text{color:var(--text-bright);word-break:break-word}.timestamp{font-size:10px;color:var(--text-dim);margin-bottom:4px}.assistant-text{color:var(--text);word-break:break-word;margin:6px 0;padding-left:4px;line-height:1.6}.assistant-text p{margin:.4em 0}.assistant-text pre{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px 12px;overflow-x:auto;margin:8px 0;line-height:1.4}.assistant-text pre code{background:none;padding:0;border-radius:0;font-size:inherit}.assistant-text code{background:var(--bg);padding:1px 5px;border-radius:3px;font-size:.92em}.assistant-text h3,.assistant-text h4,.assistant-text h5,.assistant-text h6{color:var(--text-bright);margin:.8em 0 .3em;line-height:1.3}.assistant-text h3{font-size:1.15em}.assistant-text h4{font-size:1.05em}.assistant-text h5,.assistant-text h6{font-size:1em}.assistant-text ul,.assistant-text ol{margin:.4em 0;padding-left:1.6em}.assistant-text li{margin:.15em 0}.assistant-text a{color:var(--blue);text-decoration:underline;text-decoration-color:color-mix(in srgb,var(--blue) 40%,transparent)}.assistant-text a:hover{text-decoration-color:var(--blue)}.assistant-text strong{color:var(--text-bright)}.assistant-text hr{border:none;border-top:1px solid var(--border);margin:.8em 0}.assistant-text table,.user-text table,.thinking-body table{border-collapse:collapse;margin:8px 0;font-size:.95em;width:auto;overflow-x:auto;display:block}.assistant-text th,.assistant-text td,.user-text th,.user-text td,.thinking-body th,.thinking-body td{border:1px solid var(--border);padding:4px 10px;text-align:left}.assistant-text th,.user-text th,.thinking-body th{background:var(--bg-surface);color:var(--text-bright);font-weight:600}.bg-task-badge{display:inline-block;background:var(--bg-surface);border:1px solid var(--border);border-radius:4px;padding:2px 8px;font-size:12px;color:var(--text);margin:4px 0}.bg-task-badge:before{content:\"\\26a1  \"}.user-text pre,.thinking-body pre{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px 12px;overflow-x:auto;margin:8px 0}.user-text pre code,.thinking-body pre code{background:none;padding:0;border-radius:0}.user-text code,.thinking-body code{background:var(--bg);padding:1px 5px;border-radius:3px;font-size:.92em}.user-text a,.thinking-body a{color:var(--blue);text-decoration:underline}.user-text strong,.thinking-body strong{color:var(--text-bright)}.user-text ul,.user-text ol,.thinking-body ul,.thinking-body ol{margin:.4em 0;padding-left:1.6em}.user-text p,.thinking-body p{margin:.4em 0}.tool-block{margin:6px 0;border:1px solid var(--border);border-radius:6px;overflow:hidden;background:var(--tool-bg)}.tool-header{display:flex;align-items:center;gap:6px;padding:6px 10px;cursor:pointer;user-select:none;transition:background .15s}.tool-header:hover{background:var(--bg-hover)}.tool-indicator{width:8px;height:8px;border-radius:50%;background:var(--blue);flex-shrink:0}.tool-name{color:var(--cyan);font-weight:600}.tool-args-preview{color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.tool-chevron{color:var(--text-dim);font-size:10px;transition:transform .2s;flex-shrink:0}.tool-block.open .tool-chevron{transform:rotate(90deg)}.tool-body{display:none;border-top:1px solid var(--border)}.tool-block.open .tool-body{display:block}.tool-input,.tool-result{padding:8px 10px;font-size:12px;white-space:pre-wrap;word-break:break-word;max-height:300px;overflow-y:auto}.tool-input{color:var(--text-dim);background:var(--tool-bg)}.tool-result{background:var(--bg);border-top:1px solid var(--border);color:var(--green)}.tool-result-label,.tool-input-label{font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:var(--text-dim);margin-bottom:4px;font-weight:600}.diff-view{font-family:inherit;font-size:12px;padding:8px 10px;white-space:pre-wrap;word-break:break-word;max-height:300px;overflow-y:auto}.diff-file{color:var(--text-dim);font-size:11px;margin-bottom:6px}.diff-line-del{color:var(--red);background:#f851491a}.diff-line-add{color:var(--green);background:#3fb9501a}.diff-line-ctx{color:var(--text-dim)}.diff-result{color:var(--text-dim);font-size:11px;padding:6px 10px;border-top:1px solid var(--border)}.diff-result-error{color:var(--red)}.tool-indicator.tool-error{background:var(--red)}.tool-result.tool-result-error{color:var(--red)}.tool-group{margin:6px 0}.tool-group-header{display:flex;align-items:center;gap:6px;padding:6px 10px;cursor:pointer;user-select:none;font-size:12px;color:var(--cyan);font-weight:600;border:1px solid var(--border);border-radius:6px;background:var(--tool-bg);transition:background .15s}.tool-group-header:hover{background:var(--bg-hover)}.tool-group-chevron{font-size:10px;color:var(--text-dim);transition:transform .2s}.tool-group.open .tool-group-chevron{transform:rotate(90deg)}.tool-group-names{color:var(--text-dim);font-weight:400;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.tool-group-body{display:none}.tool-group.open .tool-group-body{display:block}.tool-group.open .tool-group-header{border-radius:6px 6px 0 0;border-bottom:none}.thinking-block{margin:6px 0;border-left:2px solid var(--text-dim);padding-left:10px}.thinking-header{font-size:11px;color:var(--text);cursor:pointer;user-select:none;display:flex;align-items:center;gap:4px}.thinking-chevron{font-size:10px;transition:transform .2s}.thinking-block.open .thinking-chevron{transform:rotate(90deg)}.thinking-body{display:none;color:var(--text-dim);font-size:12px;word-break:break-word;margin-top:4px;max-height:400px;overflow-y:auto}.thinking-block.open .thinking-body{display:block}.turn-header{display:flex;align-items:center;gap:8px;padding:6px 12px;background:var(--bg-surface);border-bottom:1px solid var(--border);border-radius:6px 6px 0 0;cursor:pointer;user-select:none;font-size:11px;color:var(--text-dim)}.turn-header:hover{background:var(--bg-hover)}.turn-header-chevron{font-size:10px;transition:transform .2s}.turn.collapsed .turn-header-chevron{transform:rotate(-90deg)}.turn-header-label{font-weight:600;color:var(--text)}.turn-header-ts{margin-left:auto;font-size:10px}.turn-body{overflow:hidden;transition:max-height .3s ease}.turn.collapsed .turn-body{display:none}.role-section{padding:8px 12px;margin:4px 0;border-radius:4px}.role-section.role-user{background:var(--bg-surface);border-left:3px solid var(--accent)}.role-section.role-assistant{border-left:3px solid var(--cyan)}.role-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;margin-bottom:4px}.role-label.role-user-label{color:var(--accent)}.role-label.role-assistant-label{color:var(--cyan)}.role-label.role-system-label{color:var(--text);font-style:italic}.collapsible-wrap{position:relative}.collapsible-wrap.is-collapsed .collapsible-content{max-height:13em;overflow:hidden}.collapsible-wrap.is-collapsed .collapsible-fade{display:block;position:absolute;bottom:24px;left:0;right:0;height:3em;background:linear-gradient(transparent,var(--bg));pointer-events:none}.role-section.role-user .collapsible-wrap.is-collapsed .collapsible-fade{background:linear-gradient(transparent,var(--bg-surface))}.collapsible-fade{display:none}.collapsible-toggle{display:inline-block;font-size:11px;color:var(--accent);cursor:pointer;padding:2px 0;user-select:none;border:none;background:none;font-family:inherit}.collapsible-toggle:hover{text-decoration:underline}.cursor{display:inline-block;width:7px;height:14px;background:var(--accent);animation:blink 1s step-end infinite;vertical-align:text-bottom;margin-left:2px}@keyframes blink{50%{opacity:0}}.block-spinner{display:none;width:10px;height:10px;border:1.5px solid var(--text-dim);border-top-color:var(--text);border-radius:50%;animation:spin .8s linear infinite;flex-shrink:0}.block-active .block-spinner{display:inline-block}.block-active{border-left:2px solid var(--accent);padding-left:6px}@keyframes spin{to{transform:rotate(360deg)}}@media(max-width:600px){.controls-row{padding:6px 8px}.controls button{min-height:40px;min-width:40px;padding:6px 10px;font-size:14px}.filter-popover label{font-size:14px;padding:6px 0}.filter-popover input[type=checkbox]{width:18px;height:18px}.controls-secondary{gap:10px}}.turn-dot{position:absolute;width:5px;height:5px;border-radius:50%;background:var(--text-dim);top:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:1;opacity:.5}.turn-dot.reached{opacity:1;background:var(--text)}.bookmark-dot{position:absolute;width:8px;height:8px;border-radius:50%;background:var(--orange);top:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:2;opacity:.3;transition:opacity .3s,transform .15s}.bookmark-dot.reached{opacity:.6}.bookmark-dot.active{opacity:1;transform:translate(-50%,-50%) scale(1.4)}.bookmark-divider{display:flex;align-items:center;gap:8px;margin:16px 0 8px;padding:4px 0 4px 8px;border-left:3px solid var(--orange);font-size:11px;font-weight:600;color:var(--orange);text-transform:uppercase;letter-spacing:.5px;opacity:.25;transition:opacity .4s}.bookmark-divider.visible{opacity:1}.chapter-wrap{position:relative;flex-shrink:0}.chapter-menu{display:none;position:absolute;bottom:calc(100% + 6px);left:50%;transform:translate(-50%);background:var(--bg-surface);border:1px solid var(--border);border-radius:6px;padding:4px 0;z-index:200;box-shadow:0 4px 12px #0000004d;min-width:160px;max-width:280px;max-height:300px;overflow-y:auto}.chapter-wrap.open .chapter-menu{display:block}.chapter-item{display:flex;align-items:center;gap:8px;padding:6px 12px;cursor:pointer;font-size:12px;color:var(--text);white-space:nowrap;transition:background .15s}.chapter-item:hover{background:var(--bg-hover)}.chapter-item-turn{color:var(--text-dim);font-size:10px;min-width:24px}.chapter-item-label{color:var(--orange);font-weight:600;overflow:hidden;text-overflow:ellipsis}.splash{position:fixed;inset:0;z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:32px;background:var(--bg)}.splash.hidden{display:none}.splash-title{color:var(--text);font-size:22px;font-weight:600;text-align:center;max-width:600px;padding:0 24px}.splash-play{width:64px;height:64px;border-radius:50%;border:2px solid var(--accent);background:transparent;color:var(--accent);font-size:24px;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .2s,color .2s;padding-left:4px}.splash-play:hover{background:var(--accent);color:var(--bg)}.block-hidden{display:none}.block-revealing{animation:blockFadeIn .2s ease-out}@keyframes blockFadeIn{0%{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}::-webkit-scrollbar{width:6px;height:6px}::-webkit-scrollbar-track{background:transparent}::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}::-webkit-scrollbar-thumb:hover{background:var(--text-dim)}.file-sidebar{position:fixed;top:0;right:max(0px,calc((100vw - 960px)/2));width:260px;bottom:0;background:var(--bg-surface);border-left:1px solid var(--border);z-index:90;display:none;flex-direction:column;font-size:12px}.file-sidebar.open{display:flex}.file-sidebar-header{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border-bottom:1px solid var(--border);flex-shrink:0}.file-sidebar-title{font-weight:600;color:var(--text)}.file-sidebar-count{color:var(--text-dim);font-weight:400}.file-sidebar-close{background:none;border:none;color:var(--text-dim);font-size:18px;cursor:pointer;padding:0 4px}.file-sidebar-close:hover{color:var(--text)}.file-sidebar-list{flex:1;min-height:0;overflow-y:auto;padding:8px 0}.file-entry{padding:0}.file-entry-header{display:flex;align-items:center;gap:6px;padding:5px 12px;cursor:pointer;color:var(--text);user-select:none}.file-entry-header:hover{background:var(--bg-hover)}.file-entry-header.active{border-left:2px solid var(--accent);padding-left:10px;color:var(--accent)}.file-entry-chevron{font-size:8px;color:var(--text-dim);transition:transform .15s;flex-shrink:0}.file-entry.expanded .file-entry-chevron{transform:rotate(90deg)}.file-entry-name{flex:1;overflow:hidden;min-width:0}.file-entry-name-main{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.file-entry-name-path{display:block;font-size:9px;color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.file-entry-badge{font-size:10px;color:var(--text-dim);background:var(--bg-hover);padding:1px 5px;border-radius:8px;flex-shrink:0}.file-entry-refs{display:none;padding:2px 12px 6px 32px}.file-entry.expanded .file-entry-refs{display:block}.file-entry-ref{display:block;padding:3px 8px;margin:1px 0;color:var(--text-dim);font-size:11px;cursor:pointer;border-radius:3px;text-decoration:none}.file-entry-ref:hover{background:var(--bg-hover);color:var(--text)}.file-entry-ref .ref-tool{color:var(--accent)}.file-sidebar-toggle{font-size:13px}.file-sidebar-toggle2{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--text-dim);text-decoration:none;padding:4px 0;cursor:pointer;white-space:nowrap}.file-sidebar-toggle2:hover{color:var(--text)}\n<\/style>\n<\/head>\n<body>\n<div class=\"container\">\n  <div class=\"controls\">\n    <div class=\"controls-row\">\n      <div class=\"nav-group\">\n        <button id=\"btn-prev-turn\" title=\"Previous turn\">&#x23EE;&#xFE0E;<\/button>\n        <button id=\"btn-prev\" title=\"Previous block\">&larr;<\/button>\n        <button id=\"btn-play\" title=\"Play / Pause\">&#9654;<\/button>\n        <button id=\"btn-next\" title=\"Next block\">&rarr;<\/button>\n        <button id=\"btn-next-turn\" title=\"Next turn\">&#x23ED;&#xFE0E;<\/button>\n      <\/div>\n      <a class=\"bar-title\" id=\"bar-title\" title=\"/*PAGE_TITLE*/\">/*PAGE_TITLE*/<\/a>\n      <span class=\"progress-text\" id=\"progress-text\">0 of 0<\/span>\n      <div class=\"controls-secondary\">\n        <div class=\"chapter-wrap\" id=\"chapter-wrap\" style=\"display:none\">\n          <button id=\"chapter-btn\" title=\"Chapters\">&#9776;<\/button>\n          <div class=\"chapter-menu\" id=\"chapter-menu\"><\/div>\n        <\/div>\n        <div class=\"speed-wrap\" id=\"speed-wrap\">\n          <button id=\"speed-btn\" title=\"Speed\">/*INITIAL_SPEED*/x<\/button>\n          <div class=\"speed-popover\" id=\"speed-popover\"><\/div>\n        <\/div>\n        <div class=\"filter-wrap\" id=\"filter-wrap\">\n          <button id=\"filter-btn\" title=\"Filter content\"><svg width=\"14\" height=\"14\" viewBox=\"0 0 16 16\" fill=\"currentColor\"><path d=\"M1 2.5A.5.5 0 0 1 1.5 2h13a.5.5 0 0 1 .4.8L10 8.7V13.5a.5.5 0 0 1-.7.5l-2.5-1.2a.5.5 0 0 1-.3-.5V8.7L1.1 2.8A.5.5 0 0 1 1 2.5z\"/><\/svg><\/button>\n          <div class=\"filter-popover\">\n            <label><input type=\"checkbox\" id=\"toggle-thinking\" /*CHECKED_THINKING*/> Thinking<\/label>\n            <label><input type=\"checkbox\" id=\"toggle-tools\" /*CHECKED_TOOLS*/> Tools<\/label>\n            <div class=\"font-size-row\">\n              <span class=\"font-size-row-label\">Font<\/span>\n              <button class=\"font-size-cycle\" id=\"font-size-cycle\" title=\"Cycle font size\">M<\/button>\n            <\/div>\n          <\/div>\n        <\/div>\n        <button class=\"file-sidebar-toggle\" id=\"fileSidebarToggle\" title=\"Files\" style=\"display:none\"><svg width=\"14\" height=\"14\" viewBox=\"0 0 16 16\" fill=\"currentColor\"><path d=\"M3.5 0A1.5 1.5 0 0 0 2 1.5v13A1.5 1.5 0 0 0 3.5 16h9a1.5 1.5 0 0 0 1.5-1.5V4.5L10 0H3.5zM10 1l3.5 3.5H10V1zM4 7h8v1H4V7zm0 2h8v1H4V9zm0 2h5v1H4v-1z\"/><\/svg><\/button>\n      <\/div>\n      <div class=\"more-wrap\" id=\"more-wrap\">\n        <button id=\"more-btn\" title=\"More\">&#x22EE;<\/button>\n        <div class=\"more-popover\" id=\"more-popover\">\n          <a class=\"more-open-link\" id=\"more-open-link\" href=\"#\" target=\"_blank\" rel=\"noopener\">Open in new tab &#x2197;<\/a>\n          <hr class=\"more-divider\">\n          <div class=\"more-row\">\n            <span class=\"more-row-label\">Speed<\/span>\n            <button id=\"speed-btn2\" title=\"Cycle speed\">/*INITIAL_SPEED*/x<\/button>\n          <\/div>\n          <label class=\"paced-toggle2\" id=\"paced-toggle-wrap2\" style=\"display:none\" title=\"Smooth out pauses — timing based on content length instead of real time\"><input type=\"checkbox\" id=\"toggle-paced2\"> Auto-paced<\/label>\n          <hr class=\"more-divider\">\n          <label><input type=\"checkbox\" id=\"toggle-thinking2\" /*CHECKED_THINKING*/> Thinking<\/label>\n          <label><input type=\"checkbox\" id=\"toggle-tools2\" /*CHECKED_TOOLS*/> Tools<\/label>\n          <hr class=\"more-divider\">\n          <div class=\"more-row\">\n            <span class=\"more-row-label\">Font<\/span>\n            <button class=\"font-size-cycle\" title=\"Cycle font size\">M<\/button>\n          <\/div>\n          <div id=\"fileSidebarToggle2Wrap\" style=\"display:none\">\n            <hr class=\"more-divider\">\n            <a class=\"file-sidebar-toggle2\" id=\"fileSidebarToggle2\" href=\"#\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 16 16\" fill=\"currentColor\"><path d=\"M3.5 0A1.5 1.5 0 0 0 2 1.5v13A1.5 1.5 0 0 0 3.5 16h9a1.5 1.5 0 0 0 1.5-1.5V4.5L10 0H3.5zM10 1l3.5 3.5H10V1zM4 7h8v1H4V7zm0 2h8v1H4V9zm0 2h5v1H4v-1z\"/><\/svg> Files<\/a>\n          <\/div>\n          <div id=\"more-chapters\" style=\"display:none\">\n            <hr class=\"more-divider\">\n            <div id=\"more-chapter-list\"><\/div>\n          <\/div>\n        <\/div>\n      <\/div>\n    <\/div>\n    <div class=\"progress-wrap\">\n      <div class=\"progress-bar\" id=\"progress-bar\">\n        <div class=\"progress-fill\" id=\"progress-fill\"><\/div>\n        <div class=\"progress-tooltip\" id=\"progress-tooltip\"><\/div>\n      <\/div>\n    <\/div>\n  <\/div>\n  <div id=\"splash\" class=\"splash\">\n    <div class=\"splash-title\">/*PAGE_TITLE*/<\/div>\n    <button class=\"splash-play\" id=\"splash-play\">&#9654;<\/button>\n  <\/div>\n  <div class=\"transcript\" id=\"transcript\" style=\"opacity:0.5\">Loading...<\/div>\n  <div class=\"file-sidebar\" id=\"fileSidebar\">\n  <div class=\"file-sidebar-header\">\n    <span class=\"file-sidebar-title\">Files <span class=\"file-sidebar-count\" id=\"fileSidebarCount\"><\/span><\/span>\n    <button class=\"file-sidebar-close\" id=\"fileSidebarClose\">&times;<\/button>\n  <\/div>\n  <div class=\"file-sidebar-list\" id=\"fileSidebarList\"><\/div>\n<\/div>\n<\/div>\n\n\x3cscript>\n(async function(){\"use strict\";async function bt(t){if(t.startsWith(\"[\")||t.startsWith(\"{\"))return JSON.parse(t);if(typeof DecompressionStream>\"u\")throw document.getElementById(\"transcript\").textContent=\"This replay uses compressed data, but your browser does not support DecompressionStream. Please use a modern browser (Chrome 80+, Firefox 113+, Safari 16.4+), or rebuild with --no-compress.\",new Error(\"DecompressionStream not supported\");const e=Uint8Array.from(atob(t),o=>o.charCodeAt(0)),n=new DecompressionStream(\"deflate\"),s=n.writable.getWriter();return s.write(e),s.close(),JSON.parse(await new Response(n.readable).text())}const b=await bt(\"/*TURNS_DATA*/\"),ot=await bt(\"/*BOOKMARKS_DATA*/\"),O=await bt(\"/*FILES_DATA*/\"),X=[.5,1,2,3,5],fe=600,ue=800,pe=1e4,F=20,he=5e3,me=600,Rt=/*HAS_REAL_TIMESTAMPS*/false;let ge=!1;function ve(){const t=b.length>0&&b[0].timestamp?new Date(b[0].timestamp).getTime():null,e=b.map(o=>o.timestamp?new Date(o.timestamp).getTime():0),n=b.map(o=>{let l=o.timestamp?new Date(o.timestamp).getTime():0;for(const r of o.blocks||[])r.timestamp&&(l=Math.max(l,new Date(r.timestamp).getTime())),r.tool_call?.resultTimestamp&&(l=Math.max(l,new Date(r.tool_call.resultTimestamp).getTime()));return l}),s=t!=null&&n.length?n[n.length-1]-t:0;return{start:t,starts:e,ends:n,total:s}}function be(){let t=0;const e=[],n=[];for(const s of b){e.push(t),t+=500;for(const o of s.blocks||[]){const l=(o.text||\"\").length;t+=Math.min(Math.max(l*30,1e3),1e4)}n.push(t)}return{start:0,starts:e,ends:n,total:t}}const J=ve(),ke=be();let $=J.start,Nt=J.starts,Ot=J.ends,lt=J.total;function Ft(t){ge=t;const e=t?ke:J;$=e.start,Nt=e.starts,Ot=e.ends,lt=e.total,I=0,mt(),gt(),P()}function it(t){if(t<=0)return\"0:00\";const e=Math.round(t/1e3),n=Math.floor(e/3600),s=Math.floor(e%3600/60),o=e%60;return n>0?n+\":\"+String(s).padStart(2,\"0\")+\":\"+String(o).padStart(2,\"0\"):s+\":\"+String(o).padStart(2,\"0\")}const Yt=new Map;for(const t of ot)Yt.set(t.turn,t.label);const d=t=>document.querySelector(t),V=t=>document.querySelectorAll(t),A=d(\"#transcript\"),Z=d(\"#btn-play\"),we=d(\"#btn-prev\"),Le=d(\"#btn-next\"),ye=d(\"#btn-prev-turn\"),Se=d(\"#btn-next-turn\"),Te=d(\"#progress-fill\"),Ee=d(\"#progress-text\"),_=d(\"#progress-bar\"),Wt=d(\"#progress-tooltip\"),Ut=d(\"#speed-btn\"),jt=d(\"#speed-btn2\"),rt=d(\"#speed-wrap\"),kt=d(\"#speed-popover\"),wt=d(\"#filter-wrap\"),xe=d(\"#filter-btn\"),ct=d(\"#toggle-thinking\"),at=d(\"#toggle-tools\");let Lt=d(\"#toggle-paced\");const Ae=d(\"#toggle-thinking2\"),_e=d(\"#toggle-tools2\"),dt=d(\"#toggle-paced2\"),ft=d(\"#more-wrap\"),$e=d(\"#more-btn\"),z=d(\"#chapter-wrap\"),Me=d(\"#chapter-btn\"),Ce=d(\"#chapter-menu\"),Ie=d(\"#bar-title\"),Be=d(\".controls\"),yt=d(\"#splash\");let i=0,w=!1,St=null,M=/*INITIAL_SPEED*/1,T=null,E=null,C=0,Y=null,Tt=!1,G=null,I=0;function g(t){const e=document.createElement(\"div\");return e.textContent=t,e.innerHTML}function Et(t){if(!t)return\"\";const e=[],s=t.replace(/```([^\\n]*)\\n([\\s\\S]*?)```/g,(r,c,p)=>{const f=e.length;return e.push(`<pre><code${c?` class=\"language-${g(c)}\"`:\"\"}>${g(p.replace(/\\n$/,\"\"))}<\/code><\/pre>`),`\\0CB${f}\\0`}).split(`\n`);let o=\"\",l=null;for(let r=0;r<s.length;r++){let c=s[r];const p=c.match(/^\\x00CB(\\d+)\\x00$/);if(p){l&&(o+=`<\/${l}>`,l=null),o+=e[parseInt(p[1])];continue}if(/^---+$/.test(c.trim())){l&&(o+=`<\/${l}>`,l=null),o+=\"<hr>\";continue}const f=c.match(/^(#{1,4})\\s+(.+)$/);if(f){l&&(o+=`<\/${l}>`,l=null);const h=Math.min(f[1].length+2,6);o+=`<h${h}>${Q(g(f[2]))}<\/h${h}>`;continue}const u=c.match(/^(\\s*)[-*]\\s+(.+)$/);if(u){l!==\"ul\"&&(l&&(o+=`<\/${l}>`),o+=\"<ul>\",l=\"ul\"),o+=`<li>${Q(g(u[2]))}<\/li>`;continue}const a=c.match(/^(\\s*)\\d+\\.\\s+(.+)$/);if(a){l!==\"ol\"&&(l&&(o+=`<\/${l}>`),o+=\"<ol>\",l=\"ol\"),o+=`<li>${Q(g(a[2]))}<\/li>`;continue}if(l&&c.trim()===\"\"&&(o+=`<\/${l}>`,l=null),c.trim().startsWith(\"|\")&&r+1<s.length&&/^\\|[\\s:-]+\\|/.test(s[r+1].trim())){l&&(o+=`<\/${l}>`,l=null);const h=L=>L.replace(/^\\||\\|$/g,\"\").split(\"|\").map(v=>Q(g(v.trim()))),m=h(c);r++;let k=[];for(;r+1<s.length&&s[r+1].trim().startsWith(\"|\");)r++,k.push(h(s[r]));o+=\"<table><thead><tr>\"+m.map(L=>`<th>${L}<\/th>`).join(\"\")+\"<\/tr><\/thead>\",k.length&&(o+=\"<tbody>\"+k.map(L=>\"<tr>\"+L.map(v=>`<td>${v}<\/td>`).join(\"\")+\"<\/tr>\").join(\"\")+\"<\/tbody>\"),o+=\"<\/table>\";continue}c.trim()===\"\"?o.length>0&&(o+=`\n`):o+=`<p>${Q(g(c))}<\/p>`}return l&&(o+=`<\/${l}>`),o}function Q(t){return t=t.replace(/`([^`]+)`/g,\"<code>$1<\/code>\"),t=t.replace(/\\*\\*(.+?)\\*\\*/g,\"<strong>$1<\/strong>\"),t=t.replace(/(?<!\\w)\\*([^*]+?)\\*(?!\\w)/g,\"<em>$1<\/em>\"),t=t.replace(/\\[([^\\]]+)\\]\\((https?:\\/\\/[^)]+)\\)/g,'<a href=\"$2\" target=\"_blank\" rel=\"noopener noreferrer\">$1<\/a>'),t}function De(t,e){if(!t)return\"\";const s=(typeof t==\"string\"?t:JSON.stringify(t)).replace(/\\n/g,\" \").trim();return s.length>e?s.slice(0,e)+\"...\":s}function qe(t){if(typeof t==\"string\")return g(t);try{return g(JSON.stringify(t,null,2))}catch{return g(String(t))}}function He(t){const e=t.name||\"\",n=t.input||{};if(e===\"Edit\"||e===\"Write\"||e===\"Read\")return n.file_path||\"\";if(e===\"Grep\"||e===\"Glob\"){const s=n.pattern||\"\";return n.path?s+\" in \"+n.path:s}return e===\"Bash\"?n.command||\"\":De(n,60)}function Pe(t){const e=t.name||\"\",n=t.input||{};if(e===\"Edit\"&&n.old_string!=null&&n.new_string!=null){const o=n.file_path||\"\",l=String(n.old_string).split(`\n`),r=String(n.new_string).split(`\n`);let c=`<div class=\"diff-view\"><div class=\"diff-file\">${g(o)}${n.replace_all?\" (replace all)\":\"\"}<\/div>`;const p=l.length,f=r.length;if(p*f>5e4){for(const m of l)c+=`<div class=\"diff-line-del\">${g(\"\\u2212 \"+m)}<\/div>`;for(const m of r)c+=`<div class=\"diff-line-add\">${g(\"+ \"+m)}<\/div>`;if(c+=\"<\/div>\",t.result!=null){const m=t.is_error?\" diff-result-error\":\"\";c+=`<div class=\"diff-result${m}\">${g(t.result)}<\/div>`}return c}const u=Array.from({length:p+1},()=>new Array(f+1).fill(0));for(let m=p-1;m>=0;m--)for(let k=f-1;k>=0;k--)u[m][k]=l[m]===r[k]?u[m+1][k+1]+1:Math.max(u[m+1][k],u[m][k+1]);let a=0,h=0;for(;a<p||h<f;)a<p&&h<f&&l[a]===r[h]?(c+=`<div class=\"diff-line-ctx\">${g(\"  \"+l[a])}<\/div>`,a++,h++):h<f&&(a>=p||u[a][h+1]>=u[a+1][h])?(c+=`<div class=\"diff-line-add\">${g(\"+ \"+r[h])}<\/div>`,h++):(c+=`<div class=\"diff-line-del\">${g(\"\\u2212 \"+l[a])}<\/div>`,a++);if(c+=\"<\/div>\",t.result!=null){const m=t.is_error?\" diff-result-error\":\"\";c+=`<div class=\"diff-result${m}\">${g(t.result)}<\/div>`}return c}if(e===\"Write\"&&n.content!=null){const o=n.file_path||\"\";let l=`<div class=\"diff-view\"><div class=\"diff-file\">${g(o)}<\/div><pre style=\"margin:0;background:none;border:none;padding:0;overflow:visible;\"><code>${g(n.content)}<\/code><\/pre><\/div>`;if(t.result!=null){const r=t.is_error?\" diff-result-error\":\"\";l+=`<div class=\"diff-result${r}\">${g(t.result)}<\/div>`}return l}let s=`<div class=\"tool-input\"><div class=\"tool-input-label\">Input<\/div>${qe(n)}<\/div>`;if(t.result!=null){const o=t.is_error?\" tool-result-error\":\"\";s+=`<div class=\"tool-result${o}\" data-type=\"result\"><div class=\"tool-result-label\">Result<\/div>${g(t.result)}<\/div>`}return s}function Kt(t){return t?t.split(`\n`).length:0}function Xt(t,e,n){return e<=n?t:`<div class=\"collapsible-wrap is-collapsed\">\n      <div class=\"collapsible-content\">${t}<\/div>\n      <div class=\"collapsible-fade\"><\/div>\n      <button class=\"collapsible-toggle\" onclick=\"toggleCollapsible(this)\">Show more (${e} lines)<\/button>\n    <\/div>`}window.toggleCollapsible=function(t){const e=t.closest(\".collapsible-wrap\"),n=e.classList.toggle(\"is-collapsed\"),s=e.querySelector(\".collapsible-content\").textContent.split(`\n`).length;t.textContent=n?`Show more (${s} lines)`:\"Show less\"};function Re(t){return t.toISOString().replace(\"T\",\" \").replace(/\\.\\d+Z$/,\" UTC\")}function B(){return Be.offsetHeight}function ut(t){for(const e of t.querySelectorAll(\".open\"))e.classList.remove(\"open\")}function Ne(){yt.classList.remove(\"hidden\")}function W(){yt.classList.add(\"hidden\")}function Oe(){return!yt.classList.contains(\"hidden\")}function xt(t){return b.length>1?(t-1)/(b.length-1):t?1:0}function Jt(t){return Math.min(b.length,Math.round(t*(b.length-1))+1)}function y(){return A.querySelectorAll(\".turn\")}function At(t){for(const e of t.querySelectorAll(\".block-wrapper.block-hidden\"))e.classList.remove(\"block-hidden\")}function pt(t){for(const e of t.querySelectorAll(\".block-wrapper\"))e.classList.add(\"block-hidden\"),e.classList.remove(\"block-revealing\",\"block-active\")}function tt(){for(const t of A.querySelectorAll(\".bookmark-divider\")){const e=parseInt(t.dataset.turn,10);t.classList.toggle(\"visible\",e<=i)}}function Fe(){Ut.textContent=M+\"x\",jt.textContent=M+\"x\";for(const t of kt.querySelectorAll(\"button\"))t.classList.toggle(\"active\",parseFloat(t.dataset.speed)===M)}function Vt(t){M=t,Fe()}function Ye(t,e){const n=document.createElement(\"div\");n.className=\"turn\",n.dataset.index=t.index;let s=\"\",o=\"\",l=\"\";if(t.timestamp){const p=new Date(t.timestamp);if(l=Re(p),$!=null){const f=p.getTime()-$;o=it(f)}}const r=o||l?`<span class=\"turn-header-ts\" ${l?`title=\"${l}\"`:\"\"}>${o||l}<\/span>`:\"\",c=e??t.index;if(s+=`<div class=\"turn-header\" onclick=\"this.parentElement.classList.toggle('collapsed')\">\n      <span class=\"turn-header-chevron\">&#9660;<\/span>\n      <span class=\"turn-header-label\">#${c}<\/span>\n      ${r}\n    <\/div>`,s+='<div class=\"turn-body\">',t.user_text){const p=Kt(t.user_text),f=`<div class=\"user-text\">${Et(t.user_text)}<\/div>`;s+=`<div class=\"role-section role-user\">\n        <div class=\"role-label role-user-label\">/*USER_LABEL*/<\/div>\n        ${Xt(f,p,10)}\n      <\/div>`}if(t.system_events&&t.system_events.length){s+='<div class=\"role-section role-system\">',s+='<div class=\"role-label role-system-label\">System<\/div>';for(const p of t.system_events)s+=`<div class=\"bg-task-badge\">${g(p)}<\/div>`;s+=\"<\/div>\"}if(t.blocks.length>0){s+='<div class=\"role-section role-assistant\">',s+='<div class=\"role-label role-assistant-label\">/*ASSISTANT_LABEL*/<\/div>';const p=[];let f=[],u=0;for(const a of t.blocks)a.kind===\"tool_use\"&&a.tool_call?f.push(a):(f.length>0&&(p.push({type:\"tools\",blocks:f,blockIdx:u++}),f=[]),p.push({type:\"single\",block:a,blockIdx:u++}));f.length>0&&p.push({type:\"tools\",blocks:f,blockIdx:u++});for(const a of p){const h=\" block-hidden\";if(a.type===\"single\"){const m=a.block;if(m.kind===\"text\"){const k=Kt(m.text),L=`<div class=\"assistant-text\">${Et(m.text)}<\/div>`;s+=`<div class=\"block-wrapper${h}\" data-block-idx=\"${a.blockIdx}\">${Xt(L,k,15)}<\/div>`}else m.kind===\"thinking\"&&(s+=`<div class=\"block-wrapper${h}\" data-block-idx=\"${a.blockIdx}\"><div class=\"thinking-block\" data-type=\"thinking\">\n              <div class=\"thinking-header\" onclick=\"this.parentElement.classList.toggle('open')\">\n                <span class=\"thinking-chevron\">&#9654;<\/span> Thinking <span class=\"block-spinner\"><\/span>\n              <\/div>\n              <div class=\"thinking-body\">${Et(m.text)}<\/div>\n            <\/div><\/div>`)}else{const m=a.blocks.map(k=>{const L=k.tool_call,v=He(L),S=Pe(L);return`<div class=\"tool-block\" data-type=\"tool\">\n              <div class=\"tool-header\" onclick=\"this.parentElement.classList.toggle('open')\">\n                <span class=\"tool-indicator${L.is_error?\" tool-error\":\"\"}\"><\/span>\n                <span class=\"tool-name\">${g(L.name)}<\/span>\n                <span class=\"tool-args-preview\">${g(v)}<\/span>\n                <span class=\"block-spinner\"><\/span>\n                <span class=\"tool-chevron\">&#9654;<\/span>\n              <\/div>\n              <div class=\"tool-body\">${S}<\/div>\n            <\/div>`}).join(\"\");if(a.blocks.length<=4)s+=`<div class=\"block-wrapper${h}\" data-block-idx=\"${a.blockIdx}\">${m}<\/div>`;else{const k=a.blocks.map(S=>S.tool_call.name),L=[...new Set(k)].join(\", \"),v=a.blocks.some(S=>S.tool_call.is_error);s+=`<div class=\"block-wrapper${h}\" data-block-idx=\"${a.blockIdx}\"><div class=\"tool-group\" data-type=\"tool\">\n              <div class=\"tool-group-header\" onclick=\"this.parentElement.classList.toggle('open')\">\n                <span class=\"tool-group-chevron\">&#9654;<\/span>\n                ${v?'<span class=\"tool-indicator tool-error\" style=\"display:inline-block;margin-right:4px;\"><\/span>':\"\"}${a.blocks.length} tool calls\n                <span class=\"tool-group-names\">${g(L)}<\/span>\n                <span class=\"block-spinner\"><\/span>\n              <\/div>\n              <div class=\"tool-group-body\">${m}<\/div>\n            <\/div><\/div>`}}}s+=\"<\/div>\"}return s+=\"<\/div>\",n.innerHTML=s,n}function We(){for(let t=0;t<b.length;t++){const e=b[t],n=Yt.get(e.index);if(n){const o=document.createElement(\"div\");o.className=\"bookmark-divider\",o.dataset.turn=e.index,o.textContent=n,A.appendChild(o)}const s=Ye(e,t+1);A.appendChild(s)}}function ht(){const t=ct.checked,e=at.checked;for(const n of V('[data-type=\"thinking\"]'))n.style.display=t?\"\":\"none\";for(const n of V('[data-type=\"tool\"]'))n.style.display=e?\"\":\"none\"}function D(){Y&&(cancelAnimationFrame(Y),Y=null)}function Ue(t,e,n){D();const s=window.scrollY,o=t-s;if(Math.abs(o)<2){n&&n();return}const l=performance.now(),r=!!n;function c(p){if(r&&!w){D();return}const f=p-l,u=Math.min(f/e,1),a=u<.5?2*u*u:-1+(4-2*u)*u;window.scrollTo(0,s+o*a),u<1?Y=requestAnimationFrame(c):(Y=null,n&&n())}Y=requestAnimationFrame(c)}function je(t){C=Date.now()+2e3,requestAnimationFrame(()=>{requestAnimationFrame(()=>{const e=t.getBoundingClientRect().bottom+window.scrollY,n=B(),s=window.innerHeight-n,o=Math.max(0,e-s+F),l=Math.abs(o-window.scrollY);if(l<2)return;const r=Math.min(me+l*.3,1500);Ue(o,r)})})}function q(t,{skipScroll:e=!1,hideActiveBlocks:n=!1}={}){i=Math.min(t,b.length);const s=y();for(let o=0;o<s.length;o++){const l=s[o];o<i?(l.classList.add(\"visible\"),w||(n&&o===i-1?pt(l):At(l))):(ut(l),l.classList.remove(\"visible\"),pt(l))}if(tt(),P(),nt(i-1),!e&&i>0){const o=s[i-1];o&&je(o)}}function Zt(t,e){let n=0;const s=100;let o=null;function l(){if(t-n*M<=0){e();return}n+=s,o=setTimeout(l,s)}return l(),function(){clearTimeout(o)}}function _t(t,e,n){const s=b[t];if(!s)return e(),function(){};const o=y()[t];if(!o)return e(),function(){};const l=o.querySelectorAll(\".block-wrapper\");if(l.length===0)return e(),function(){};const r=[];let c=[];for(const v of s.blocks)v.kind===\"tool_use\"&&v.tool_call?c.push(v):(c.length>0&&(r.push({type:\"tools\",blocks:c}),c=[]),r.push({type:\"single\",block:v}));c.length>0&&r.push({type:\"tools\",blocks:c});function p(v){return v.type===\"single\"?v.block.timestamp||null:v.blocks[0]&&v.blocks[0].timestamp||null}const f=[0];for(let v=1;v<r.length&&v<l.length;v++){const S=p(r[v]),N=p(r[v-1]);let st;S&&N?st=new Date(S).getTime()-new Date(N).getTime():st=ue,f.push(Math.min(Math.max(st,fe),pe))}let u=!1,a=null,h=n||0;function m(v){const S=l[v];if(!S)return;const N=o.querySelector(\".block-active\");N&&N.classList.remove(\"block-active\"),S.classList.remove(\"block-hidden\"),S.classList.add(\"block-revealing\"),S.classList.add(\"block-active\"),requestAnimationFrame(()=>{const st=B(),ae=window.innerHeight-st,de=S.getBoundingClientRect();if(de.bottom>ae){D();const Ze=de.bottom+window.scrollY-ae+20;window.scrollTo({top:Ze,behavior:v===0?\"smooth\":\"instant\"})}})}function k(){if(u||h>=f.length){if(!u){for(const N of o.querySelectorAll(\".block-active\"))N.classList.remove(\"block-active\");E=null,e()}return}const v=h,S=f[v];if(h++,S===0){m(v),k();return}a=Zt(S,()=>{u||(a=null,m(v),k())})}function L(){u||(u=!0,a&&(a(),a=null),E={turnIndex:t,blockIdx:h})}return k(),L}function et(){T=Zt(he,()=>{w&&(T=null,zt())})}function zt(){if(!w)return;if(i>=b.length){x();return}const t=i===0;if(q(i+1,{skipScroll:!0}),t){const s=y()[0];if(s){const o=B(),l=window.innerHeight-o,r=s.getBoundingClientRect().bottom+window.scrollY;window.scrollTo({top:Math.max(0,r-l+F),behavior:\"instant\"})}}const e=y()[i-1];if(!e){x();return}if(e.querySelectorAll(\".block-wrapper\").length===0){U(e),et();return}T=_t(i-1,()=>{T=null,w&&et()})}function $t(){if(W(),i>=b.length){const t=y()[b.length-1];if(t&&t.querySelectorAll(\".block-wrapper.block-hidden\").length>0)i=b.length;else{i=0,E=null;for(const n of A.children)ut(n),n.classList.remove(\"visible\");for(const n of A.querySelectorAll(\".block-wrapper\"))n.classList.add(\"block-hidden\"),n.classList.remove(\"block-revealing\")}}if(w=!0,te(),Z.innerHTML=\"&#9646;&#9646;\",Z.classList.add(\"active\"),i>0){const t=y()[i-1];t&&U(t)}if(E){const t=E;E=null,T=_t(t.turnIndex,()=>{T=null,w&&et()},t.blockIdx);return}if(i>0){const t=y()[i-1];if(t){const e=t.querySelectorAll(\".block-wrapper:not(.block-hidden)\").length,n=t.querySelectorAll(\".block-wrapper\").length;if(e<n){T=_t(i-1,()=>{T=null,w&&et()},e);return}if(e>0&&n>0){et();return}}}zt()}function x(){w=!1,ee(),D(),Z.innerHTML=\"&#9654;\",Z.classList.remove(\"active\"),St&&(clearTimeout(St),St=null),T&&(T(),T=null)}function H(t,e){w&&x(),E=null,t<=0?(q(0),Ne()):(W(),q(Math.min(t,b.length),e))}function Mt(t){requestAnimationFrame(()=>{const e=B(),n=window.innerHeight-e,s=t.getBoundingClientRect();if(s.bottom>n){D();const o=s.bottom+window.scrollY-n+F;window.scrollTo({top:o,behavior:\"smooth\"})}else if(s.top<0){D();const o=s.top+window.scrollY-F;window.scrollTo({top:Math.max(0,o),behavior:\"smooth\"})}})}function U(t){requestAnimationFrame(()=>{const e=B(),n=window.innerHeight-e,s=t.getBoundingClientRect().bottom+window.scrollY,o=Math.max(0,s-n+F);D(),window.scrollTo({top:o,behavior:\"smooth\"})})}function Gt(){if(w&&x(),E=null,C=Date.now()+2e3,i===0){W(),i=1;const n=y();n[0]&&(n[0].classList.add(\"visible\"),pt(n[0]),U(n[0])),tt(),P(),nt(0);return}const t=y()[i-1];if(!t)return;const e=t.querySelectorAll(\".block-wrapper.block-hidden\");if(e.length>0){const n=e[0],s=t.querySelector(\".block-active\");s&&s.classList.remove(\"block-active\"),n.classList.remove(\"block-hidden\"),n.classList.add(\"block-revealing\",\"block-active\"),gt(),Mt(n)}else if(i<b.length){const n=t.querySelector(\".block-active\");n&&n.classList.remove(\"block-active\"),i++;const o=y()[i-1];o&&(o.classList.add(\"visible\"),pt(o),Mt(o)),tt(),P(),nt(i-1)}}function Qt(){w&&x(),E=null,C=Date.now()+2e3;const t=i>0?y()[i-1]:null;if(t){const e=t.querySelectorAll(\".block-wrapper:not(.block-hidden)\");if(e.length>0){const n=e[e.length-1];ut(n),n.classList.add(\"block-hidden\"),n.classList.remove(\"block-revealing\",\"block-active\");const s=t.querySelectorAll(\".block-wrapper:not(.block-hidden)\");s.length>0?(s[s.length-1].classList.add(\"block-active\"),U(s[s.length-1])):U(t),gt();return}}if(i<=1)H(0);else{i--;const e=y(),n=e[i];n&&(ut(n),n.classList.remove(\"visible\"));const s=e[i-1];s&&(At(s),U(s)),tt(),P(),nt(i-1)}}function P(){const t=Math.max(0,xt(i)*100);Te.style.width=t+\"%\",gt(),w&&te();for(const n of _.querySelectorAll(\".turn-dot\")){const s=parseInt(n.dataset.turn,10);n.classList.toggle(\"reached\",s<=i)}let e=null;for(const n of _.querySelectorAll(\".bookmark-dot\")){const o=parseInt(n.dataset.turn,10)<=i;n.classList.toggle(\"reached\",o),n.classList.remove(\"active\"),o&&(e=n)}e&&e.classList.add(\"active\")}function mt(){Ee.textContent=it(I)+\" / \"+it(lt)}function te(){G||(G=setInterval(()=>{I=Math.min(I+1e3*M,lt),mt(),I>=lt&&ee()},1e3))}function gt(){if($==null||i<=0){I=0,mt();return}const t=i-1,e=y()[t];if(!e)return;const n=e.querySelectorAll(\".block-wrapper\").length,s=e.querySelectorAll(\".block-wrapper:not(.block-hidden)\").length,o=Nt[t]-$,l=Ot[t]-$,r=n>0?s/n:0;I=Math.round(o+(l-o)*r),mt()}function ee(){G&&(clearInterval(G),G=null)}function nt(t){for(const n of V(\".turn.active\"))n.classList.remove(\"active\");const e=y();t>=0&&t<e.length&&e[t].classList.add(\"active\")}function Ct(t){const e=_.getBoundingClientRect(),n=Math.max(0,Math.min(1,(t-e.left)/e.width)),s=Jt(n);s<=1&&n<.05?H(0):H(Math.max(1,s),{hideActiveBlocks:!0})}function Ke(){if(w||Date.now()<C||Oe())return;const t=y();if(!t.length)return;const e=window.innerHeight/2;let n=-1;for(let s=0;s<t.length;s++)t[s].getBoundingClientRect().top<e&&(n=s);if(n>=0){const s=n+1;if(s!==i){if(s>i){i=s;for(let o=0;o<t.length;o++)t[o].classList.toggle(\"visible\",o<i),o<i&&At(t[o]);tt()}else i=s;P(),nt(i-1)}}}const ne=[rt,wt,z,ft].filter(Boolean);function R(t){for(const e of ne)t&&e===t||e.classList.remove(\"open\")}document.addEventListener(\"click\",t=>{for(const e of ne)if(e.classList.contains(\"open\")&&e.contains(t.target))return;R()}),window.addEventListener(\"blur\",()=>{R()}),Z.addEventListener(\"click\",()=>w?x():$t()),Le.addEventListener(\"click\",Gt),we.addEventListener(\"click\",Qt),Se.addEventListener(\"click\",()=>vt(1)),ye.addEventListener(\"click\",()=>vt(-1)),Ut.addEventListener(\"click\",t=>{t.stopPropagation();const e=rt.classList.contains(\"open\");R(),e||rt.classList.add(\"open\")});for(let t=X.length-1;t>=0;t--){const e=X[t],n=document.createElement(\"button\");n.textContent=e+\"x\",n.dataset.speed=e,e===M&&n.classList.add(\"active\"),n.addEventListener(\"click\",s=>{s.stopPropagation(),Vt(e),rt.classList.remove(\"open\")}),kt.appendChild(n)}if(Rt){const t=document.createElement(\"label\");t.className=\"paced-toggle\",t.id=\"paced-toggle-wrap\",t.title=\"Smooth out pauses \\u2014 timing based on content length instead of real time\",t.innerHTML='<input type=\"checkbox\" id=\"toggle-paced\"> Auto-paced',kt.appendChild(t);const e=t.querySelector(\"input\");e.addEventListener(\"change\",()=>{dt.checked=e.checked,Ft(e.checked)}),Lt=e}xe.addEventListener(\"click\",t=>{t.stopPropagation();const e=wt.classList.contains(\"open\");R(),e||wt.classList.add(\"open\")}),ct.addEventListener(\"change\",ht),at.addEventListener(\"change\",ht);const It=[\"small\",\"normal\",\"large\"],se={small:\"11px\",normal:\"13px\",large:\"15px\"},Xe={small:\"S\",normal:\"M\",large:\"L\"};let Bt=/*FONT_SIZE_NAME*/\"normal\";function oe(t){Bt=t,document.body.style.setProperty(\"--font-size\",se[t]||se.normal);for(const e of V(\".font-size-cycle\"))e.textContent=Xe[t]||\"M\"}oe(Bt);for(const t of V(\".font-size-cycle\"))t.addEventListener(\"click\",e=>{e.stopPropagation();const n=It.indexOf(Bt);oe(It[(n+1)%It.length])});Rt&&(d(\"#paced-toggle-wrap2\").style.display=\"\"),dt.addEventListener(\"change\",()=>{Lt&&(Lt.checked=dt.checked),Ft(dt.checked)});const Je=d(\"#more-open-link\");$e.addEventListener(\"click\",t=>{t.stopPropagation();const e=ft.classList.contains(\"open\");if(R(),!e){const n=d(\".turn.active\"),s=n?parseInt(n.dataset.index,10):i;Je.href=location.href.replace(/#.*/,\"\")+\"#turn=\"+s,ft.classList.add(\"open\")}}),jt.addEventListener(\"click\",()=>{const t=X.indexOf(M);Vt(X[(t+1)%X.length])});function le(t,e){e.addEventListener(\"change\",()=>{t.checked=e.checked,ht()}),t.addEventListener(\"change\",()=>{e.checked=t.checked})}le(ct,Ae),le(at,_e),_.addEventListener(\"click\",t=>Ct(t.clientX)),_.addEventListener(\"touchstart\",t=>{t.preventDefault(),Ct(t.touches[0].clientX)},{passive:!1}),_.addEventListener(\"touchmove\",t=>{t.preventDefault(),Ct(t.touches[0].clientX)},{passive:!1}),_.addEventListener(\"mousemove\",t=>{const e=_.getBoundingClientRect(),n=Math.max(0,Math.min(1,(t.clientX-e.left)/e.width)),s=Jt(n),o=b[s-1];let l=`#${s}`;if(o&&o.timestamp&&$!=null){const c=new Date(o.timestamp).getTime()-$;l+=` \\xB7 ${it(c)}`}Wt.textContent=l;const r=Math.max(20,Math.min(e.width-20,t.clientX-e.left));Wt.style.left=r+\"px\"}),A.addEventListener(\"click\",t=>{w&&(t.target.closest(\".turn-header\")||t.target.closest(\".thinking-header\")||t.target.closest(\".tool-header\")||t.target.closest(\".tool-group-header\")||t.target.closest(\".collapsible-toggle\"))&&x()});function vt(t){w&&x(),E=null,C=Date.now()+2e3;const e=t>0?Math.min(i+1,b.length):Math.max(i-1,0);H(e,{hideActiveBlocks:!0})}let j=null;function ie(t){w&&x(),E=null,C=Date.now()+2e3;const e=ct.checked,n=at.checked,s=[],o=y();for(const u of o)for(const a of u.querySelectorAll(\".block-wrapper\")){if(e)for(const h of a.querySelectorAll('[data-type=\"thinking\"]'))s.push(h);if(n)for(const h of a.querySelectorAll('[data-type=\"tool\"]'))s.push(h)}if(s.length===0)return;let l=-1;if(j&&(l=s.indexOf(j)),l<0&&i>0){const u=o[i-1];if(u){for(let a=s.length-1;a>=0;a--)if(u.contains(s[a])){l=a;break}if(l<0)for(let a=s.length-1;a>=0;a--){const h=s[a].closest(\".turn\");if((h?parseInt(h.dataset.index,10):0)<=i){l=a;break}}}}let r;t>0?r=l<0?0:Math.min(l+1,s.length-1):r=l<0?s.length-1:Math.max(l-1,0);const c=s[r],p=c.closest(\".turn\");if(p){const u=parseInt(p.dataset.index,10);u!==i&&(W(),q(u,{skipScroll:!0}))}j&&j!==c&&j.classList.remove(\"open\"),c.classList.add(\"open\"),j=c;const f=c.closest(\".block-wrapper\");if(f){const u=A.querySelector(\".block-active\");u&&u.classList.remove(\"block-active\"),f.classList.add(\"block-active\")}Mt(c)}document.addEventListener(\"keydown\",t=>{if(t.target.tagName!==\"INPUT\"){if((t.key===\" \"||t.key===\"k\")&&(t.preventDefault(),w?x():$t()),t.shiftKey&&(t.key===\"ArrowRight\"||t.key===\"L\")){t.preventDefault(),vt(1);return}if(t.shiftKey&&(t.key===\"ArrowLeft\"||t.key===\"H\")){t.preventDefault(),vt(-1);return}(t.key===\"ArrowRight\"||t.key===\"l\")&&(t.preventDefault(),Gt()),(t.key===\"ArrowLeft\"||t.key===\"h\")&&(t.preventDefault(),Qt()),t.key===\"t\"&&(t.preventDefault(),ie(1)),t.key===\"T\"&&(t.preventDefault(),ie(-1))}});let Dt=!1;try{Dt=window!==window.top}catch{Dt=!0}Dt&&(document.body.classList.add(\"in-iframe\"),Ie.addEventListener(\"click\",()=>{const t=d(\".turn.active\"),e=t?parseInt(t.dataset.index,10):i,n=location.href.replace(/#.*/,\"\")+\"#turn=\"+e;window.open(n,\"_blank\")})),window.addEventListener(\"scroll\",()=>{Tt||(Tt=!0,requestAnimationFrame(()=>{Ke(),Tt=!1}))},{passive:!0});for(let t=0;t<b.length;t++){const e=document.createElement(\"div\");e.className=\"turn-dot\",e.dataset.turn=t+1,e.style.left=xt(t+1)*100+\"%\",_.appendChild(e)}if(ot.length>0){z.style.display=\"\";for(const n of ot){const s=document.createElement(\"div\");s.className=\"bookmark-dot\",s.dataset.turn=n.turn,s.style.left=xt(n.turn)*100+\"%\",_.appendChild(s)}const t=d(\"#more-chapters\"),e=d(\"#more-chapter-list\");t.style.display=\"\";for(const n of ot){const s=document.createElement(\"div\");s.className=\"chapter-item\",s.title=n.label,s.innerHTML=`<span class=\"chapter-item-turn\">#${n.turn}<\/span><span class=\"chapter-item-label\">${g(n.label)}<\/span>`,s.addEventListener(\"click\",()=>{H(n.turn,{hideActiveBlocks:!0}),z.classList.remove(\"open\")}),Ce.appendChild(s);const o=document.createElement(\"div\");o.className=\"chapter-item\",o.innerHTML=s.innerHTML,o.addEventListener(\"click\",()=>{H(n.turn,{hideActiveBlocks:!0}),ft.classList.remove(\"open\")}),e.appendChild(o)}Me.addEventListener(\"click\",n=>{n.stopPropagation();const s=z.classList.contains(\"open\");R(),s||z.classList.add(\"open\")})}A.textContent=\"\",A.style.opacity=\"\",We(),ht();const qt=location.hash.match(/turn=(\\d+)(r)?/);if(qt){const t=Math.min(parseInt(qt[1],10),b.length),e=qt[2]===\"r\";t>0&&(W(),e?(q(t,{hideActiveBlocks:!1,skipScroll:!0}),C=Date.now()+2e3,requestAnimationFrame(()=>{requestAnimationFrame(()=>{const n=y()[t-1];if(n){const s=B(),o=window.innerHeight-s,r=(n.querySelector(\".block-wrapper:last-child\")||n).getBoundingClientRect().bottom+window.scrollY;window.scrollTo(0,Math.max(0,r-o+F))}})})):q(t,{hideActiveBlocks:!0}))}P();let re=location.hash;window.addEventListener(\"hashchange\",()=>{if(location.hash===re)return;re=location.hash;const t=location.hash.match(/turn=(\\d+)(r)?/);if(!t)return;const e=Math.min(parseInt(t[1],10),b.length),n=t[2]===\"r\";e>0&&(x(),W(),q(e,{hideActiveBlocks:!n}))}),d(\"#splash-play\").addEventListener(\"click\",()=>$t());const K=d(\"#fileSidebar\"),Ht=d(\"#fileSidebarList\"),ce=d(\"#fileSidebarToggle\"),Ve=d(\"#fileSidebarCount\");if(O.length>0){const t=Math.max(...O.map(o=>o.name.length)),e=Math.min(260,Math.max(180,t*8+70));K.style.width=e+\"px\";const n=document.createElement(\"style\");n.textContent=\"body.sidebar-open .transcript { margin-right: \"+e+\"px; }\",document.head.appendChild(n),ce.style.display=\"\",d(\"#fileSidebarToggle2Wrap\").style.display=\"\",Ve.textContent=\"(\"+O.length+\")\";let s=\"\";for(const o of O){const l=new Set(o.refs.map(f=>f.tool)),r=o.refs.length>1?`<span class=\"file-entry-badge\">${o.refs.length}<\/span>`:\"\";s+=`<div class=\"file-entry\" data-path=\"${g(o.path)}\">`;const c=o.relPath||o.path,p=c.includes(\"/\")?c.slice(0,c.lastIndexOf(\"/\")):\"\";s+=`<div class=\"file-entry-header\"><span class=\"file-entry-chevron\">&#9654;<\/span><span class=\"file-entry-name\" title=\"${g(o.path)}\"><span class=\"file-entry-name-main\">${g(o.name)}<\/span>${p?`<span class=\"file-entry-name-path\">${g(p)}<\/span>`:\"\"}<\/span>${r}<\/div>`,s+='<div class=\"file-entry-refs\">';for(const f of o.refs)s+=`<a class=\"file-entry-ref\" data-turn=\"${f.turn}\" data-block=\"${f.block}\"><span class=\"ref-tool\">${f.tool}<\/span> in turn ${f.turn}<\/a>`;s+=\"<\/div><\/div>\"}Ht.innerHTML=s,Ht.addEventListener(\"click\",o=>{const l=o.target.closest(\".file-entry-header\");if(l){l.closest(\".file-entry\").classList.toggle(\"expanded\");return}const r=o.target.closest(\".file-entry-ref\");if(r){const c=parseInt(r.dataset.turn);if(c>0){H(c,{hideActiveBlocks:!1}),C=Date.now()+2e3;const p=r.closest(\".file-entry\")?.dataset.path,f=r.querySelector(\".ref-tool\")?.textContent;if(p){const u=y()[c-1];if(u){const a=p.split(\"/\").pop();for(const h of u.querySelectorAll(\".tool-block\")){const m=h.querySelector(\".tool-name\"),k=h.querySelector(\".tool-args-preview\");if(m&&k&&m.textContent===f&&k.textContent.includes(a)){const L=h.closest(\".tool-group\");L&&L.classList.add(\"open\"),h.classList.add(\"open\");break}}}}window.innerWidth<=700&&K.classList.remove(\"open\")}}})}function Pt(t){const e=t!==void 0?t:!K.classList.contains(\"open\");e&&(K.style.bottom=B()+\"px\"),K.classList.toggle(\"open\",e),document.body.classList.toggle(\"sidebar-open\",e)}if(ce.addEventListener(\"click\",()=>Pt()),d(\"#fileSidebarToggle2\").addEventListener(\"click\",t=>{t.preventDefault(),R(),Pt()}),d(\"#fileSidebarClose\").addEventListener(\"click\",()=>Pt(!1)),O.length>0){const t=new Map;for(const n of O)for(const s of n.refs)t.has(s.turn)||t.set(s.turn,new Set),t.get(s.turn).add(n.path);let e=-1;setInterval(()=>{if(!K.classList.contains(\"open\")||i===e)return;e=i;const n=t.get(i)||new Set;for(const s of Ht.querySelectorAll(\".file-entry-header\")){const o=s.closest(\".file-entry\").dataset.path;s.classList.toggle(\"active\",n.has(o))}},300)}document.body.dataset.ready=\"1\"})();\n<\/script>\n<\/body>\n<\/html>\n";
 const DEMO_FIXTURE = "{\"index\":1,\"user_text\":\"Create a simple Express hello world server. Install dependencies, start the\\nserver, curl it to verify it works, then stop the server.\",\"blocks\":[{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:48:33.283Z\",\"tool_call\":{\"name\":\"Bash\",\"input\":{\"command\":\"ls /Users/enrico/Personal/demo_express/\",\"description\":\"List current directory contents\"},\"result\":\"(Bash completed with no output)\",\"resultTimestamp\":\"2026-03-17T17:48:33.664Z\"}},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:48:37.714Z\",\"tool_call\":{\"name\":\"Bash\",\"input\":{\"command\":\"npm init -y\",\"description\":\"Initialize npm project\"},\"result\":\"Wrote to /Users/enrico/Personal/demo_express/package.json:\\n\\n{\\n  \\\"name\\\": \\\"demo_express\\\",\\n  \\\"version\\\": \\\"1.0.0\\\",\\n  \\\"main\\\": \\\"index.js\\\",\\n  \\\"scripts\\\": {\\n    \\\"test\\\": \\\"echo \\\\\\\"Error: no test specified\\\\\\\" && exit 1\\\"\\n  },\\n  \\\"keywords\\\": [],\\n  \\\"author\\\": \\\"\\\",\\n  \\\"license\\\": \\\"ISC\\\",\\n  \\\"description\\\": \\\"\\\"\\n}\",\"resultTimestamp\":\"2026-03-17T17:48:40.106Z\"}},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:48:43.749Z\",\"tool_call\":{\"name\":\"Bash\",\"input\":{\"command\":\"npm install express\",\"description\":\"Install Express\"},\"result\":\"added 65 packages, and audited 66 packages in 467ms\\n\\n22 packages are looking for funding\\n  run `npm fund` for details\\n\\nfound 0 vulnerabilities\",\"resultTimestamp\":\"2026-03-17T17:48:45.490Z\"}},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:48:49.709Z\",\"tool_call\":{\"name\":\"Write\",\"input\":{\"file_path\":\"/Users/enrico/Personal/demo_express/index.js\",\"content\":\"const express = require(\\\"express\\\");\\nconst app = express();\\nconst port = 3000;\\n\\napp.get(\\\"/\\\", (req, res) => {\\n  res.send(\\\"Hello World!\\\");\\n});\\n\\napp.listen(port, () => {\\n  console.log(`Server listening on port ${port}`);\\n});\\n\"},\"result\":\"File created successfully at: /Users/enrico/Personal/demo_express/index.js\",\"resultTimestamp\":\"2026-03-17T17:48:51.413Z\"}},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:48:55.517Z\",\"tool_call\":{\"name\":\"Bash\",\"input\":{\"command\":\"node /Users/enrico/Personal/demo_express/index.js &\",\"description\":\"Start Express server in background\",\"timeout\":5000},\"result\":\"(Bash completed with no output)\",\"resultTimestamp\":\"2026-03-17T17:48:57.019Z\"}},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:48:59.986Z\",\"tool_call\":{\"name\":\"Bash\",\"input\":{\"command\":\"curl http://localhost:3000\",\"description\":\"Test the server\"},\"result\":\"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\\n                                 Dload  Upload   Total   Spent    Left  Speed\\n\\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\\r100    12  100    12    0     0   2171      0 --:--:-- --:--:-- --:--:--  2400\\nHello World!\",\"resultTimestamp\":\"2026-03-17T17:49:02.146Z\"}},{\"kind\":\"text\",\"text\":\"Server responds with `Hello World!`. Now stopping it.\",\"timestamp\":\"2026-03-17T17:49:05.563Z\"},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:49:06.358Z\",\"tool_call\":{\"name\":\"Bash\",\"input\":{\"command\":\"kill $(lsof -ti:3000) 2>/dev/null; echo \\\"Server stopped\\\"\",\"description\":\"Stop the Express server\"},\"result\":\"Server stopped\",\"resultTimestamp\":\"2026-03-17T17:49:08.795Z\"}},{\"kind\":\"text\",\"text\":\"Done. The Express server is set up in `index.js`, listening on port 3000, and verified working with `curl`. The server has been stopped.\",\"timestamp\":\"2026-03-17T17:49:12.030Z\"}],\"timestamp\":\"2026-03-17T17:48:28.819Z\",\"bookmark\":\"Setup\"}\n{\"index\":2,\"user_text\":\"Can you add a /health endpoint that returns status ok?\",\"blocks\":[{\"kind\":\"thinking\",\"text\":\"The user wants a health check endpoint. I'll add a simple GET /health route to the Express server that returns a JSON response.\",\"timestamp\":\"2026-03-17T17:50:03.000Z\"},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:50:03.000Z\",\"tool_call\":{\"name\":\"Edit\",\"input\":{\"file_path\":\"/Users/enrico/Personal/demo_express/index.js\",\"old_string\":\"app.get('/', (req, res) => {\\n  res.send('Hello World!');\\n});\",\"new_string\":\"app.get('/', (req, res) => {\\n  res.send('Hello World!');\\n});\\n\\napp.get('/health', (req, res) => {\\n  res.json({ status: 'ok' });\\n});\"},\"result\":\"Updated /Users/enrico/Personal/demo_express/index.js\",\"resultTimestamp\":\"2026-03-17T17:50:03.500Z\"}},{\"kind\":\"text\",\"text\":\"Added a `/health` endpoint. Let me test it:\",\"timestamp\":\"2026-03-17T17:50:05.000Z\"},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:50:05.000Z\",\"tool_call\":{\"name\":\"Bash\",\"input\":{\"command\":\"curl -s http://localhost:3000/health\"},\"result\":\"{\\\"status\\\":\\\"ok\\\"}\",\"resultTimestamp\":\"2026-03-17T17:50:06.000Z\"}},{\"kind\":\"text\",\"text\":\"The `/health` endpoint is working — returns `{\\\"status\\\": \\\"ok\\\"}` as expected.\",\"timestamp\":\"2026-03-17T17:50:07.000Z\"}],\"timestamp\":\"2026-03-17T17:50:00.000Z\"}\n{\"index\":3,\"user_text\":\"Now add a simple test using the built-in node test runner\",\"blocks\":[{\"kind\":\"thinking\",\"text\":\"I'll create a test file using Node.js built-in test runner that tests both the / and /health endpoints.\",\"timestamp\":\"2026-03-17T17:51:04.000Z\"},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:51:04.000Z\",\"tool_call\":{\"name\":\"Write\",\"input\":{\"file_path\":\"/Users/enrico/Personal/demo_express/test.mjs\",\"content\":\"import { describe, it } from 'node:test';\\nimport assert from 'node:assert/strict';\\n\\nconst BASE = 'http://localhost:3000';\\n\\ndescribe('Express server', () => {\\n  it('GET / returns Hello World', async () => {\\n    const res = await fetch(BASE + '/');\\n    assert.equal(res.status, 200);\\n    const text = await res.text();\\n    assert.equal(text, 'Hello World!');\\n  });\\n\\n  it('GET /health returns ok', async () => {\\n    const res = await fetch(BASE + '/health');\\n    assert.equal(res.status, 200);\\n    const data = await res.json();\\n    assert.deepEqual(data, { status: 'ok' });\\n  });\\n});\\n\"},\"result\":\"Created /Users/enrico/Personal/demo_express/test.mjs\",\"resultTimestamp\":\"2026-03-17T17:51:04.500Z\"}},{\"kind\":\"text\",\"text\":\"Let me run the tests:\",\"timestamp\":\"2026-03-17T17:51:06.000Z\"},{\"kind\":\"tool_use\",\"text\":\"\",\"timestamp\":\"2026-03-17T17:51:06.000Z\",\"tool_call\":{\"name\":\"Bash\",\"input\":{\"command\":\"cd /Users/enrico/Personal/demo_express && node --test test.mjs\"},\"result\":\"TAP version 13\\n# Subtest: Express server\\n    # Subtest: GET / returns Hello World\\n    ok 1 - GET / returns Hello World\\n    # Subtest: GET /health returns ok\\n    ok 2 - GET /health returns ok\\n    1..2\\nok 1 - Express server\\n1..1\\n# tests 2\\n# suites 1\\n# pass 2\\n# fail 0\",\"resultTimestamp\":\"2026-03-17T17:51:08.000Z\"}},{\"kind\":\"text\",\"text\":\"Both tests pass. The server has:\\n\\n- `GET /` → returns \\\"Hello World!\\\"\\n- `GET /health` → returns `{\\\"status\\\": \\\"ok\\\"}`\\n\\nWith a test suite covering both endpoints.\",\"timestamp\":\"2026-03-17T17:51:10.000Z\"}],\"timestamp\":\"2026-03-17T17:51:00.000Z\",\"bookmark\":\"Testing\"}\n{\"index\":4,\"user_text\":\"Great, thanks!\",\"blocks\":[{\"kind\":\"text\",\"text\":\"You're welcome! You now have a working Express server with a hello world endpoint, a health check, and passing tests. Let me know if you need anything else.\",\"timestamp\":\"2026-03-17T17:52:02.000Z\"}],\"timestamp\":\"2026-03-17T17:52:00.000Z\"}";
 
 const $ = (id) => document.getElementById(id);

--- a/scripts/build-website.mjs
+++ b/scripts/build-website.mjs
@@ -58,7 +58,7 @@ const html = `<!DOCTYPE html>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>claude-replay — Turn AI coding sessions into shareable HTML replays</title>
-<meta name="description" content="Convert Claude Code, Cursor, and Codex session logs into interactive, self-contained HTML replays.">
+<meta name="description" content="Convert Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, and Kimi Code session logs into interactive, self-contained HTML replays.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='14' fill='none' stroke='%23bb9af7' stroke-width='2'/><polygon points='12,8 12,24 24,16' fill='%23bb9af7'/></svg>">
 <style>
 :root {
@@ -167,7 +167,7 @@ kbd { background: var(--bg-surface); border: 1px solid var(--border); padding: 1
   <div class="hero">
     <h1><span class="accent">claude-replay</span></h1>
     <p>Turn AI coding sessions into interactive, shareable HTML replays.</p>
-    <p class="sub">Supports Claude Code, Cursor, and Codex transcripts. Single self-contained HTML file, zero dependencies.</p>
+    <p class="sub">Supports Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, and Kimi Code transcripts. Single self-contained HTML file, zero dependencies.</p>
     <div class="hero-actions">
       <div class="install-box" id="installNpm" title="Click to copy">
         <code>npm install -g claude-replay</code>
@@ -217,7 +217,7 @@ kbd { background: var(--bg-surface); border: 1px solid var(--border); padding: 1
   <div class="features">
     <h2>Features</h2>
     <div class="feature-grid">
-      <div class="feature-card"><h3>Multi-format</h3><p>Supports Claude Code, Cursor, and Codex CLI transcripts. Auto-detected.</p></div>
+      <div class="feature-card"><h3>Multi-format</h3><p>Supports Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, and Kimi Code transcripts. Auto-detected.</p></div>
       <div class="feature-card"><h3>Self-contained</h3><p>Single HTML file with no external dependencies. Email it, host it, embed it.</p></div>
       <div class="feature-card"><h3>Web Editor</h3><p>Built-in editor to browse sessions, edit prompts, exclude turns, and add bookmarks.</p></div>
       <div class="feature-card"><h3>Interactive Player</h3><p>Playback with speed control, keyboard shortcuts, diff views, and chapter navigation.</p></div>

--- a/src/editor-server.mjs
+++ b/src/editor-server.mjs
@@ -503,6 +503,36 @@ function discoverSessions() {
     if (codexGroup.projects.length > 0) groups.push(codexGroup);
   } catch { /* directory doesn't exist */ }
 
+  // Kimi Code: ~/.kimi-code/sessions/<project>/<session>/agents/main/wire.jsonl
+  const kimiBase = join(home, ".kimi-code", "sessions");
+  try {
+    const kimiGroup = { name: "Kimi Code", projects: [] };
+    for (const proj of readdirSync(kimiBase).sort()) {
+      const projPath = join(kimiBase, proj);
+      try { if (!statSync(projPath).isDirectory()) continue; } catch { continue; }
+      const kimiSessions = [];
+      for (const sessionDir of readdirSync(projPath)) {
+        if (!sessionDir.startsWith("session_")) continue;
+        const wirePath = join(projPath, sessionDir, "agents", "main", "wire.jsonl");
+        try {
+          const stat = statSync(wirePath);
+          kimiSessions.push({ file: sessionDir, path: wirePath, date: stat.mtime.toISOString() });
+        } catch { continue; }
+      }
+      if (kimiSessions.length === 0) continue;
+      kimiSessions.sort((a, b) => {
+        if (!a.date && !b.date) return 0;
+        if (!a.date) return 1;
+        if (!b.date) return -1;
+        return b.date.localeCompare(a.date);
+      });
+      const parts = proj.replace(/^wd_/, "").split("_");
+      const displayName = parts.length > 1 ? parts.slice(-2).join("-") : parts[0];
+      kimiGroup.projects.push({ name: displayName, dirName: proj, sessions: kimiSessions });
+    }
+    if (kimiGroup.projects.length > 0) groups.push(kimiGroup);
+  } catch { /* directory doesn't exist */ }
+
   return groups;
 }
 

--- a/src/editor-server.mjs
+++ b/src/editor-server.mjs
@@ -503,7 +503,7 @@ function discoverSessions() {
     if (codexGroup.projects.length > 0) groups.push(codexGroup);
   } catch { /* directory doesn't exist */ }
 
-  // Kimi Code: ~/.kimi-code/sessions/<project>/<session>/agents/main/wire.jsonl
+  // Kimi Code: ~/.kimi-code/sessions/<project>/<session>/agents/<name>/wire.jsonl
   const kimiBase = join(home, ".kimi-code", "sessions");
   try {
     const kimiGroup = { name: "Kimi Code", projects: [] };
@@ -513,11 +513,17 @@ function discoverSessions() {
       const kimiSessions = [];
       for (const sessionDir of readdirSync(projPath)) {
         if (!sessionDir.startsWith("session_")) continue;
-        const wirePath = join(projPath, sessionDir, "agents", "main", "wire.jsonl");
-        try {
-          const stat = statSync(wirePath);
-          kimiSessions.push({ file: sessionDir, path: wirePath, date: stat.mtime.toISOString() });
-        } catch { continue; }
+        const agentsDir = join(projPath, sessionDir, "agents");
+        let agentNames;
+        try { agentNames = readdirSync(agentsDir); } catch { continue; }
+        for (const agentName of agentNames) {
+          const wirePath = join(agentsDir, agentName, "wire.jsonl");
+          try {
+            const st = statSync(wirePath);
+            const label = agentName === "main" ? sessionDir : `${sessionDir}/${agentName}`;
+            kimiSessions.push({ file: label, path: wirePath, date: st.mtime.toISOString() });
+          } catch { /* no wire.jsonl for this agent */ }
+        }
       }
       if (kimiSessions.length === 0) continue;
       kimiSessions.sort((a, b) => {

--- a/src/editor-server.mjs
+++ b/src/editor-server.mjs
@@ -279,7 +279,7 @@ function buildRenderOpts(options, session, overrides = {}) {
     redactSecrets: options.redactSecrets !== false,
     redactRules: options.redactRules || [],
     userLabel: options.userLabel || "User",
-    assistantLabel: options.assistantLabel || (session.format === "gemini" ? "Gemini" : session.format === "codex" ? "Codex" : session.format === "cursor" ? "Assistant" : session.format === "opencode" ? "OpenCode" : "Claude"),
+    assistantLabel: options.assistantLabel || (session.format === "gemini" ? "Gemini" : session.format === "codex" ? "Codex" : session.format === "cursor" ? "Assistant" : session.format === "opencode" ? "OpenCode" : session.format === "kimi-code" ? "Kimi" : "Claude"),
     title: options.title || "Replay",
     description: options.description || "",
     ogImage: options.ogImage || "",

--- a/src/formats/index.mjs
+++ b/src/formats/index.mjs
@@ -15,6 +15,7 @@ import * as claudeCode from "./claude-code.mjs";
 import * as cursor from "./cursor.mjs";
 import * as codex from "./codex.mjs";
 import * as gemini from "./gemini.mjs";
+import * as kimiCode from "./kimi-code.mjs";
 import * as opencode from "./opencode.mjs";
 import * as replay from "./replay.mjs";
 
@@ -28,6 +29,7 @@ export const formats = [
   replay,
   codex,
   opencode,
+  kimiCode,
   claudeCode,
   cursor,
 ];

--- a/src/formats/kimi-code.mjs
+++ b/src/formats/kimi-code.mjs
@@ -1,0 +1,174 @@
+/**
+ * Kimi Code wire format parser.
+ *
+ * Format: JSONL with per-turn event streaming.
+ *   - turn.prompt: starts a new turn, contains user input and timestamp
+ *   - context.append_loop_event: assistant content (think, text, tool calls, tool results)
+ *   - context.append_message: user/assistant messages (mirrors turn content)
+ *
+ * Each turn has one or more steps. Steps are bounded by step.begin/step.end.
+ * Tool calls and results are matched by toolCallId within the same turn.
+ *
+ * Timestamps are Unix milliseconds (turn.prompt.time) → converted to ISO 8601.
+ *
+ * Session path: ~/.kimi-code/sessions/<project>/<session>/agents/main/wire.jsonl
+ */
+
+import { cleanSystemTags, filterEmptyTurns } from "./shared.mjs";
+
+export const name = "kimi-code";
+
+/**
+ * Detect if a JSONL line belongs to kimi-code format.
+ * kimi-code sessions start with metadata entries and contain
+ * turn.prompt or context.append_loop_event type entries.
+ */
+export function detect(firstObj) {
+  return firstObj.type === "turn.prompt" ||
+    firstObj.type === "context.append_loop_event";
+}
+
+/**
+ * Convert Unix milliseconds to ISO 8601 string.
+ * @param {number} ms
+ * @returns {string}
+ */
+function msToISO(ms) {
+  return new Date(ms).toISOString();
+}
+
+/**
+ * Extract user text from turn.prompt input array.
+ * @param {object[]} input
+ * @returns {string}
+ */
+function extractUserText(input) {
+  if (!Array.isArray(input)) return "";
+  const parts = [];
+  for (const block of input) {
+    if (block.type === "text" && block.text) {
+      parts.push(block.text);
+    }
+  }
+  return cleanSystemTags(parts.join("\n"));
+}
+
+/**
+ * Parse kimi-code wire.jsonl text into Turn[].
+ * @param {string} text
+ * @returns {import("./shared.mjs").Turn[]}
+ */
+export function parse(text) {
+  // Parse all lines into objects
+  const entries = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      entries.push(JSON.parse(trimmed));
+    } catch { /* skip malformed */ }
+  }
+
+  // Group loop events by turnId
+  const turnPrompts = [];        // { turnId, input, time }
+  const loopEvents = new Map();  // turnId → events[]
+  let currentTurnId = "";
+
+  for (const entry of entries) {
+    if (entry.type === "turn.prompt") {
+      currentTurnId = String(turnPrompts.length);
+      turnPrompts.push({
+        turnId: currentTurnId,
+        input: entry.input,
+        time: entry.time,
+      });
+    } else if (entry.type === "context.append_loop_event") {
+      const ev = entry.event;
+      if (!ev) continue;
+      // tool.result events don't have turnId — inherit from current turn
+      const turnId = ev.turnId != null ? String(ev.turnId) : currentTurnId;
+      if (!loopEvents.has(turnId)) {
+        loopEvents.set(turnId, []);
+      }
+      loopEvents.get(turnId).push(ev);
+    }
+  }
+
+  // Build turns
+  const turns = [];
+
+  for (const tp of turnPrompts) {
+    const userText = extractUserText(tp.input);
+    const timestamp = tp.time ? msToISO(tp.time) : "";
+    const events = loopEvents.get(tp.turnId) ?? [];
+
+    const blocks = [];
+    const toolCalls = new Map(); // toolCallId → tool_call object
+
+    for (const ev of events) {
+      if (ev.type === "content.part") {
+        const part = ev.part;
+        if (!part) continue;
+
+        if (part.type === "think") {
+          const thinkText = (part.think ?? "").trim();
+          if (thinkText) {
+            blocks.push({
+              kind: "thinking",
+              text: thinkText,
+              tool_call: null,
+              timestamp: null,
+            });
+          }
+        } else if (part.type === "text") {
+          const textContent = (part.text ?? "").trim();
+          if (textContent) {
+            blocks.push({
+              kind: "text",
+              text: textContent,
+              tool_call: null,
+              timestamp: null,
+            });
+          }
+        }
+      } else if (ev.type === "tool.call") {
+        const toolId = ev.toolCallId ?? "";
+        const toolName = ev.name ?? "";
+        const args = ev.args ?? {};
+        const toolCall = {
+          tool_use_id: toolId,
+          name: toolName,
+          input: args,
+          result: null,
+          resultTimestamp: null,
+          is_error: false,
+        };
+        toolCalls.set(toolId, toolCall);
+        blocks.push({
+          kind: "tool_use",
+          text: "",
+          tool_call: toolCall,
+          timestamp: null,
+        });
+      } else if (ev.type === "tool.result") {
+        const toolId = ev.toolCallId ?? "";
+        const tc = toolCalls.get(toolId);
+        if (tc) {
+          const result = ev.result ?? {};
+          tc.result = result.output ?? null;
+          tc.is_error = !!result.isError;
+          tc.resultTimestamp = null;
+        }
+      }
+    }
+
+    turns.push({
+      index: 0, // Will be re-indexed by filterEmptyTurns
+      user_text: userText,
+      blocks,
+      timestamp,
+    });
+  }
+
+  return filterEmptyTurns(turns);
+}

--- a/src/resolve-session.mjs
+++ b/src/resolve-session.mjs
@@ -106,5 +106,27 @@ export function resolveSessionId(sessionId, { home } = {}) {
     }
   } catch { /* directory doesn't exist */ }
 
+  // Kimi Code: ~/.kimi-code/sessions/<project>/<session>/agents/main/wire.jsonl
+  const kimiBase = join(homeDir, ".kimi-code", "sessions");
+  try {
+    for (const proj of readdirSync(kimiBase)) {
+      const projPath = join(kimiBase, proj);
+      try { if (!statSync(projPath).isDirectory()) continue; } catch { continue; }
+      for (const sessionDir of readdirSync(projPath)) {
+        if (!sessionDir.startsWith("session_")) continue;
+        const sessionIdFromDir = sessionDir.replace(/^session_/, "");
+        const wirePath = join(projPath, sessionDir, "agents", "main", "wire.jsonl");
+        try {
+          statSync(wirePath);
+          if (sessionIdFromDir === sessionId || sessionIdFromDir.includes(sessionId)) {
+            const parts = proj.replace(/^wd_/, "").split("_");
+            const displayName = parts.length > 1 ? parts.slice(-2).join("-") : parts[0];
+            matches.push({ path: wirePath, project: displayName, group: "Kimi Code" });
+          }
+        } catch { /* not found */ }
+      }
+    }
+  } catch { /* directory doesn't exist */ }
+
   return matches;
 }

--- a/src/resolve-session.mjs
+++ b/src/resolve-session.mjs
@@ -106,7 +106,7 @@ export function resolveSessionId(sessionId, { home } = {}) {
     }
   } catch { /* directory doesn't exist */ }
 
-  // Kimi Code: ~/.kimi-code/sessions/<project>/<session>/agents/main/wire.jsonl
+  // Kimi Code: ~/.kimi-code/sessions/<project>/<session>/agents/<name>/wire.jsonl
   const kimiBase = join(homeDir, ".kimi-code", "sessions");
   try {
     for (const proj of readdirSync(kimiBase)) {
@@ -115,15 +115,20 @@ export function resolveSessionId(sessionId, { home } = {}) {
       for (const sessionDir of readdirSync(projPath)) {
         if (!sessionDir.startsWith("session_")) continue;
         const sessionIdFromDir = sessionDir.replace(/^session_/, "");
-        const wirePath = join(projPath, sessionDir, "agents", "main", "wire.jsonl");
-        try {
-          statSync(wirePath);
-          if (sessionIdFromDir === sessionId || sessionIdFromDir.includes(sessionId)) {
+        if (sessionIdFromDir !== sessionId && !sessionIdFromDir.includes(sessionId)) continue;
+        const agentsDir = join(projPath, sessionDir, "agents");
+        let agentNames;
+        try { agentNames = readdirSync(agentsDir); } catch { continue; }
+        for (const agentName of agentNames) {
+          const wirePath = join(agentsDir, agentName, "wire.jsonl");
+          try {
+            statSync(wirePath);
+            const label = agentName === "main" ? "Kimi Code" : `Kimi Code (${agentName})`;
             const parts = proj.replace(/^wd_/, "").split("_");
             const displayName = parts.length > 1 ? parts.slice(-2).join("-") : parts[0];
-            matches.push({ path: wirePath, project: displayName, group: "Kimi Code" });
-          }
-        } catch { /* not found */ }
+            matches.push({ path: wirePath, project: displayName, group: label });
+          } catch { /* not found */ }
+        }
       }
     }
   } catch { /* directory doesn't exist */ }

--- a/test/fixture-kimi-code.jsonl
+++ b/test/fixture-kimi-code.jsonl
@@ -1,0 +1,25 @@
+{"type":"metadata","protocol_version":"1.4","created_at":1750000000000}
+{"type":"turn.prompt","input":[{"type":"text","text":"Hello, what is 2+2?"}],"origin":{"kind":"user"},"time":1750000000000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-1a","turnId":"0","step":1}}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"think-1a","turnId":"0","step":1,"part":{"type":"think","think":"The user is asking a simple arithmetic question. I can answer directly."}}}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"text-1a","turnId":"0","step":1,"part":{"type":"text","text":"2 + 2 = 4"}}}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-1a","turnId":"0","step":1,"finishReason":"end_turn"}}
+{"type":"turn.prompt","input":[{"type":"text","text":"Read the file test.txt"}],"origin":{"kind":"user"},"time":1750000060000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-2a","turnId":"1","step":1}}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"think-2a","turnId":"1","step":1,"part":{"type":"think","think":"The user wants me to read a file. I'll use the Read tool."}}}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"call_test1","turnId":"1","step":1,"toolCallId":"call_test1","name":"Read","args":{"path":"/tmp/test.txt"}}}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-2a","turnId":"1","step":1,"finishReason":"tool_use"}}
+{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"call_test1","toolCallId":"call_test1","result":{"output":"hello world"}}}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-2b","turnId":"1","step":2}}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"think-2b","turnId":"1","step":2,"part":{"type":"think","think":"The file contains 'hello world'. I'll report this to the user."}}}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"text-2b","turnId":"1","step":2,"part":{"type":"text","text":"The file contains: hello world"}}}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-2b","turnId":"1","step":2,"finishReason":"end_turn"}}
+{"type":"turn.prompt","input":[{"type":"text","text":"Run a command that fails"}],"origin":{"kind":"user"},"time":1750000120000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-3a","turnId":"2","step":1}}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"think-3a","turnId":"2","step":1,"part":{"type":"think","think":"The user wants to run a command. Let me use Bash."}}}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"call_fail1","turnId":"2","step":1,"toolCallId":"call_fail1","name":"Bash","args":{"command":"cat /nonexistent/file"}}}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-3a","turnId":"2","step":1,"finishReason":"tool_use"}}
+{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"call_fail1","toolCallId":"call_fail1","result":{"output":"cat: /nonexistent/file: No such file or directory","isError":true}}}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-3b","turnId":"2","step":2}}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"text-3b","turnId":"2","step":2,"part":{"type":"text","text":"The command failed: file not found."}}}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-3b","turnId":"2","step":2,"finishReason":"end_turn"}}

--- a/test/test-parser.mjs
+++ b/test/test-parser.mjs
@@ -15,6 +15,7 @@ const CODEX_PATCH_FIXTURE = new URL("./fixture-codex-patch.jsonl", import.meta.u
 const CODEX_EDGES_FIXTURE = new URL("./fixture-codex-edges.jsonl", import.meta.url).pathname;
 const GEMINI_FIXTURE = new URL("./fixture-gemini.json", import.meta.url).pathname;
 const OPENCODE_FIXTURE = new URL("./fixture-opencode.jsonl", import.meta.url).pathname;
+const KIMI_CODE_FIXTURE = new URL("./fixture-kimi-code.jsonl", import.meta.url).pathname;
 
 describe("parseTranscript", () => {
   // Fixture produces 3 turns (orphan assistant after tool result merges into previous):
@@ -617,6 +618,92 @@ describe("OpenCode format", () => {
   });
 });
 
+describe("Kimi Code format", () => {
+  it("detects kimi-code format", () => {
+    assert.equal(detectFormat(KIMI_CODE_FIXTURE), "kimi-code");
+  });
+
+  it("does not confuse kimi-code with claude-code", () => {
+    assert.equal(detectFormat(FIXTURE), "claude-code");
+  });
+
+  it("parses turns from kimi-code session", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    // Fixture has 3 turn.prompt events → 3 turns
+    assert.equal(turns.length, 3);
+  });
+
+  it("extracts user text", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    assert.equal(turns[0].user_text, "Hello, what is 2+2?");
+    assert.equal(turns[1].user_text, "Read the file test.txt");
+    assert.equal(turns[2].user_text, "Run a command that fails");
+  });
+
+  it("extracts thinking blocks", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    const thinking = turns[0].blocks.filter((b) => b.kind === "thinking");
+    assert.equal(thinking.length, 1);
+    assert.match(thinking[0].text, /simple arithmetic/);
+  });
+
+  it("extracts text blocks", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    const text = turns[0].blocks.filter((b) => b.kind === "text");
+    assert.equal(text.length, 1);
+    assert.equal(text[0].text, "2 + 2 = 4");
+  });
+
+  it("maps tool calls with standard names", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    const readBlock = turns[1].blocks.find((b) => b.kind === "tool_use" && b.tool_call.name === "Read");
+    assert.ok(readBlock, "should have a Read tool_use block");
+    assert.equal(readBlock.tool_call.input.path, "/tmp/test.txt");
+  });
+
+  it("attaches tool results", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    const readBlock = turns[1].blocks.find((b) => b.kind === "tool_use" && b.tool_call.name === "Read");
+    assert.equal(readBlock.tool_call.result, "hello world");
+  });
+
+  it("marks error tool calls", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    const bashBlock = turns[2].blocks.find((b) => b.kind === "tool_use" && b.tool_call.name === "Bash");
+    assert.ok(bashBlock, "should have a Bash tool_use block");
+    assert.equal(bashBlock.tool_call.is_error, true);
+    assert.match(bashBlock.tool_call.result, /No such file/);
+  });
+
+  it("preserves timestamps as ISO strings", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    assert.ok(turns[0].timestamp, "should have a timestamp");
+    assert.match(turns[0].timestamp, /^\d{4}-\d{2}-\d{2}T/);
+    // Turn 2 is 60 seconds later
+    const t0 = new Date(turns[0].timestamp).getTime();
+    const t1 = new Date(turns[1].timestamp).getTime();
+    assert.equal(t1 - t0, 60000);
+  });
+
+  it("assigns sequential turn indices", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    assert.deepEqual(
+      turns.map((t) => t.index),
+      [1, 2, 3]
+    );
+  });
+
+  it("handles multiple steps in a turn (tool_use then text)", () => {
+    const turns = parseTranscript(KIMI_CODE_FIXTURE);
+    // Turn 2: Read tool call + thinking + text in step 2
+    const blocks = turns[1].blocks;
+    const kinds = blocks.map((b) => b.kind);
+    assert.ok(kinds.includes("thinking"));
+    assert.ok(kinds.includes("tool_use"));
+    assert.ok(kinds.includes("text"));
+  });
+});
+
 describe("Turn structure contract", () => {
   // Every format must produce turns matching the same shape.
   // This catches format parsers that forget fields or return wrong types.
@@ -626,6 +713,7 @@ describe("Turn structure contract", () => {
     { name: "codex", path: CODEX_FIXTURE },
     { name: "gemini", path: GEMINI_FIXTURE },
     { name: "opencode", path: OPENCODE_FIXTURE },
+    { name: "kimi-code", path: KIMI_CODE_FIXTURE },
   ];
 
   for (const { name, path } of fixtures) {


### PR DESCRIPTION
## Add kimi-code format support

### What

Adds support for [kimi-code](https://www.kimi.com/code) session transcripts. kimi-code stores sessions as `wire.jsonl` under `~/.kimi-code/sessions/<project>/<session>/agents/<name>/wire.jsonl`.

### How it works

Kimi-code wire format uses `turn.prompt` events for user input and `context.append_loop_event` events for assistant content (thinking, text, tool calls, tool results). The parser maps these to the standard Turn shape.

### Changes

| File | Change |
|---|---|
| `src/formats/kimi-code.mjs` | New format parser |
| `src/formats/index.mjs` | Register in detection chain |
| `src/editor-server.mjs` | Discover sessions including subagents |
| `src/resolve-session.mjs` | Session ID lookup |
| `test/fixture-kimi-code.jsonl` | 3-turn fixture |
| `test/test-parser.mjs` | 12 tests + Turn structure contract |

### Verification

- 265/265 tests pass
- oxlint: 0 warnings
- 236 real sessions parsed, 170 subagent sessions discovered