### PR TITLE
ci: fix Codex session generation after CLI flag change

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -65,7 +65,7 @@ jobs:
           touch /tmp/before-codex
           cd /tmp/test-project
           echo "$OPENAI_API_KEY" | codex login --with-api-key
-          codex exec --full-auto --skip-git-repo-check "Create a file called greeting.txt with 'hello from codex', then read it back" 2>&1 || true
+          codex exec --sandbox workspace-write --skip-git-repo-check "Create a file called greeting.txt with 'hello from codex', then read it back" 2>&1 || true
           CODEX_SESSION=$(find ~/.codex/sessions -name "*.jsonl" -newer /tmp/before-codex -type f 2>/dev/null | head -1)
           if [ -z "$CODEX_SESSION" ]; then
             echo "::error::No Codex session file generated"


### PR DESCRIPTION
The latest @openai/codex removed the --full-auto flag from 'codex exec',
causing the format-check workflow to fail with 'unexpected argument
--full-auto found'. Replace it with '--sandbox workspace-write', which
preserves the original intent (non-interactive, workspace-writable run)
under the current CLI.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B9fxpxaUHE3fUQQE3M1vom